### PR TITLE
UiPath.CoreIpc.csproj: Package reference updates

### DIFF
--- a/src/UiPath.CoreIpc/UiPath.CoreIpc.csproj
+++ b/src/UiPath.CoreIpc/UiPath.CoreIpc.csproj
@@ -19,7 +19,8 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.IO.Pipes.AccessControl" Version="4.5.1" />
     <PackageReference Include="System.Reflection.DispatchProxy" Version="4.6.0" />


### PR DESCRIPTION
- `Microsoft.Extensions.Logging` becomes `Microsoft.Extensions.Logging.Abstractions` since the only usage is the `ILogger` interface within `ServiceClient.cs`

- reintroduce `Microsoft.Extensions.DependencyInjection.Abstractions` since no other dependency references it indirectly anymore