### PR TITLE
nodejs: Downgrade TypeScript compiler from ^3.6.4 to ~3.5.0 in order to support NG CLI

### DIFF
--- a/src/Clients/nodejs/package-lock.json
+++ b/src/Clients/nodejs/package-lock.json
@@ -1392,9 +1392,9 @@
             "dev": true
         },
         "handlebars": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-            "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+            "version": "4.7.2",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.2.tgz",
+            "integrity": "sha512-4PwqDL2laXtTWZghzzCtunQUTLbo31pcCJrd/B/9JP8XbhVzpS5ZXuKqlOzsd1rtcaLo4KqAn8nl8mkknS4MHw==",
             "dev": true,
             "requires": {
                 "neo-async": "^2.6.0",
@@ -3767,9 +3767,9 @@
             }
         },
         "tree-kill": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
-            "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+            "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
             "dev": true
         },
         "trim-right": {
@@ -3985,15 +3985,15 @@
             }
         },
         "typescript": {
-            "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
-            "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+            "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
             "dev": true
         },
         "uglify-js": {
-            "version": "3.6.8",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz",
-            "integrity": "sha512-XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==",
+            "version": "3.7.6",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.6.tgz",
+            "integrity": "sha512-yYqjArOYSxvqeeiYH2VGjZOqq6SVmhxzaPjJC1W2F9e+bqvFL9QXQ2osQuKUFjM2hGjKG2YclQnRKWQSt/nOTQ==",
             "dev": true,
             "optional": true,
             "requires": {

--- a/src/Clients/nodejs/package.json
+++ b/src/Clients/nodejs/package.json
@@ -75,7 +75,7 @@
         "tslint-eslint-rules": "5.4.0",
         "typedoc": "^0.15.0",
         "typedoc-plugin-markdown": "1.2.0",
-        "typescript": "^3.6.4"
+        "typescript": "~3.5.0"
     },
     "gitHead": "edef4e238fde99232400d5270c6f54c3f054cb10"
 }


### PR DESCRIPTION
- downgraded the TypeScript compiler from ^3.6.4 to ~3.5.0 because 3.6.* introduced Ambiental get and set accessors (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-6.html#get-and-set-accessors-are-allowed-in-ambient-contexts) which are being used in emitting .d.ts files while NG Cli is currently limited to TypeScript compiler versions >=3.4.0  <3.6.0

The direct usage of @uipath/coreipc has never occurred within an NG project up until now. The @uipath/robot-client package was always in-between, and while it was compiled using a TypeScript compiler new enough to be able to understand @uipath/coreipc's definition files, it on the other hand proposed no public properties in any useful exported type.