### PR TITLE
nodejs: Reflect the Multiple Endpoints .NET feature at wire level

### DIFF
--- a/src/Clients/nodejs/src/core/internals/broker-message.ts
+++ b/src/Clients/nodejs/src/core/internals/broker-message.ts
@@ -22,6 +22,7 @@ export class InboundRequest extends Request {
 /* @internal */
 export class OutboundRequest extends Request {
     constructor(
+        public readonly endpointName: string,
         methodName: string,
         args: ReadonlyArray<any>
     ) {

--- a/src/Clients/nodejs/src/core/internals/proxy-factory.ts
+++ b/src/Clients/nodejs/src/core/internals/proxy-factory.ts
@@ -65,11 +65,13 @@ export class Generator<TService> {
 
         const traceCategory = this._traceCategory;
 
+        const endpointName = this._sampleCtor.name;
+
         return async function(this: IProxy) {
             traceCategory.log(`executing "${methodName}", stack is:\r\n${new StackTrace()}`);
             const args = normalizeArgs([...arguments]);
 
-            const brokerOutboundRequest = new BrokerMessage.OutboundRequest(methodName, args);
+            const brokerOutboundRequest = new BrokerMessage.OutboundRequest(endpointName, methodName, args);
 
             traceCategory.log(`sending brokerRequest: ${JSON.stringify(brokerOutboundRequest)}`);
             try {

--- a/src/Clients/nodejs/src/core/internals/serialization-pal.ts
+++ b/src/Clients/nodejs/src/core/internals/serialization-pal.ts
@@ -167,6 +167,7 @@ export class SerializationPal {
 
         const wireRequestFactory = (id: string) => new WireMessage.Request(
             timeoutSeconds,
+            request.endpointName,
             id,
             request.methodName,
             serializedArgs

--- a/src/Clients/nodejs/src/core/internals/wire-message.ts
+++ b/src/Clients/nodejs/src/core/internals/wire-message.ts
@@ -13,6 +13,8 @@ export class Request extends Base {
         // tslint:disable-next-line: variable-name
         public readonly TimeoutInSeconds: number,
         // tslint:disable-next-line: variable-name
+        public readonly Endpoint: string,
+        // tslint:disable-next-line: variable-name
         public readonly Id: string,
         // tslint:disable-next-line: variable-name
         public readonly MethodName: string,

--- a/src/Clients/nodejs/test/unit/core-internals/broker.test.ts
+++ b/src/Clients/nodejs/test/unit/core-internals/broker.test.ts
@@ -173,7 +173,7 @@ describe(`core:internals -> class:Broker`, () => {
                 }
             );
 
-            await broker.sendReceiveAsync(new BrokerMessage.OutboundRequest('sumAsync', [1, 2]));
+            await broker.sendReceiveAsync(new BrokerMessage.OutboundRequest('ENDPOINT_NAME', 'sumAsync', [1, 2]));
             spyConnectionFactory.should.have.been.called();
         });
 
@@ -187,7 +187,7 @@ describe(`core:internals -> class:Broker`, () => {
                 }
             );
 
-            await broker.sendReceiveAsync(new BrokerMessage.OutboundRequest('sumAsync', [1, 2]));
+            await broker.sendReceiveAsync(new BrokerMessage.OutboundRequest('ENDPOINT_NAME', 'sumAsync', [1, 2]));
             spyConnectionFactory.should.have.been.called();
         });
 
@@ -210,7 +210,7 @@ describe(`core:internals -> class:Broker`, () => {
                 methodContainer
             );
 
-            await broker.sendReceiveAsync(new BrokerMessage.OutboundRequest('sumAsync', [1, 2]));
+            await broker.sendReceiveAsync(new BrokerMessage.OutboundRequest('ENDPOINT_NAME', 'sumAsync', [1, 2]));
             spyConnectionFactory.should.have.been.called();
         });
     });
@@ -260,11 +260,11 @@ describe(`core:internals -> class:Broker`, () => {
 
             const broker = createBrokerFromLogicalSocket(ls);
 
-            await broker.sendReceiveAsync(new BrokerMessage.OutboundRequest('primerMethod', []));
+            await broker.sendReceiveAsync(new BrokerMessage.OutboundRequest('ENDPOINT_NAME', 'primerMethod', []));
             write1.should.have.been.called();
             write2.should.not.have.been.called();
 
-            data.next(SerializationPal.wireRequestToBuffer(new WireMessage.Request(2, 'id', 'callbackMethodName', [])));
+            data.next(SerializationPal.wireRequestToBuffer(new WireMessage.Request(2, 'ENDPOINT_NAME', 'id', 'callbackMethodName', [])));
 
             write2.should.not.have.been.called();
 
@@ -317,11 +317,11 @@ describe(`core:internals -> class:Broker`, () => {
             const callbackContainer = {};
             const broker = createBrokerFromLogicalSocket(ls, callbackContainer);
 
-            await broker.sendReceiveAsync(new BrokerMessage.OutboundRequest('primerMethod', []));
+            await broker.sendReceiveAsync(new BrokerMessage.OutboundRequest('ENDPOINT_NAME', 'primerMethod', []));
             write1.should.have.been.called();
             write2.should.not.have.been.called();
 
-            data.next(SerializationPal.wireRequestToBuffer(new WireMessage.Request(2, 'id', 'callbackMethodName', [])));
+            data.next(SerializationPal.wireRequestToBuffer(new WireMessage.Request(2, 'ENDPOINT_NAME', 'id', 'callbackMethodName', [])));
 
             write2.should.not.have.been.called();
 
@@ -378,8 +378,8 @@ describe(`core:internals -> class:Broker`, () => {
             };
             const broker = createBrokerFromLogicalSocket(ls, callbackContainer);
 
-            await broker.sendReceiveAsync(new BrokerMessage.OutboundRequest('primerMethod', []));
-            data.next(SerializationPal.wireRequestToBuffer(new WireMessage.Request(2, 'id', 'callbackMethod', ['3'])));
+            await broker.sendReceiveAsync(new BrokerMessage.OutboundRequest('ENDPOINT_NAME', 'primerMethod', []));
+            data.next(SerializationPal.wireRequestToBuffer(new WireMessage.Request(2, 'ENDPOINT_NAME', 'id', 'callbackMethod', ['3'])));
 
             await Promise.yield();
         });
@@ -404,7 +404,7 @@ describe(`core:internals -> class:Broker`, () => {
                     return x + y;
                 }
             });
-            const brokerRequest = new BrokerMessage.OutboundRequest('sumAsync', [1, 2]);
+            const brokerRequest = new BrokerMessage.OutboundRequest('ENDPOINT_NAME', 'sumAsync', [1, 2]);
             await broker.sendReceiveAsync(brokerRequest).
                 should.eventually.be.fulfilled.and.satisfy((x: BrokerMessage.Response) => {
                     expect(x).not.to.be.null.and.not.to.be.undefined;
@@ -430,7 +430,7 @@ describe(`core:internals -> class:Broker`, () => {
                     return x + y;
                 }
             });
-            const brokerRequest = new BrokerMessage.OutboundRequest('sumAsync', [1, 2]);
+            const brokerRequest = new BrokerMessage.OutboundRequest('ENDPOINT_NAME', 'sumAsync', [1, 2]);
             const promise = broker.sendReceiveAsync(brokerRequest);
 
             const rejectedSpy = spy(() => { });
@@ -470,9 +470,9 @@ describe(`core:internals -> class:Broker`, () => {
                     failAsync
                 });
 
-            data.next(SerializationPal.wireRequestToBuffer(new WireMessage.Request(1, 'id-1', 'succeedAsync', ['1', '2'])));
-            data.next(SerializationPal.wireRequestToBuffer(new WireMessage.Request(1, 'id-2', 'failAsync', ['1', '2'])));
-            broker.sendReceiveAsync(new BrokerMessage.OutboundRequest('inexistentMethod', [])).observe();
+            data.next(SerializationPal.wireRequestToBuffer(new WireMessage.Request(1, 'ENDPOINT_NAME', 'id-1', 'succeedAsync', ['1', '2'])));
+            data.next(SerializationPal.wireRequestToBuffer(new WireMessage.Request(1, 'ENDPOINT_NAME', 'id-2', 'failAsync', ['1', '2'])));
+            broker.sendReceiveAsync(new BrokerMessage.OutboundRequest('ENDPOINT_NAME', 'inexistentMethod', [])).observe();
 
             await Promise.yield();
             succeedAsync.should.have.been.called();
@@ -501,7 +501,7 @@ describe(`core:internals -> class:Broker`, () => {
             const broker = createBroker();
             try {
                 const invalidBrokerRequest: BrokerMessage.OutboundRequest = null as any;
-                const validBrokerRequest = new BrokerMessage.OutboundRequest('method-name', []);
+                const validBrokerRequest = new BrokerMessage.OutboundRequest('ENDPOINT_NAME', 'method-name', []);
 
                 function maybeObserve<T>(promise: Promise<T> | null | undefined): Promise<T> | null | undefined {
                     if (promise) {
@@ -534,9 +534,9 @@ describe(`core:internals -> class:Broker`, () => {
             });
 
             try {
-                const breq1 = new BrokerMessage.OutboundRequest('succeedAsync', [1, 2]);
-                const breq2 = new BrokerMessage.OutboundRequest('failLogicallyAsync', []);
-                const breq3 = new BrokerMessage.OutboundRequest('breqFailInfrastructurallyAsync', []);
+                const breq1 = new BrokerMessage.OutboundRequest('ENDPOINT_NAME', 'succeedAsync', [1, 2]);
+                const breq2 = new BrokerMessage.OutboundRequest('ENDPOINT_NAME', 'failLogicallyAsync', []);
+                const breq3 = new BrokerMessage.OutboundRequest('ENDPOINT_NAME', 'breqFailInfrastructurallyAsync', []);
 
                 const promise1 = broker.sendReceiveAsync(breq1);
                 const promise2 = broker.sendReceiveAsync(breq2);
@@ -591,7 +591,7 @@ describe(`core:internals -> class:Broker`, () => {
             };
             const broker = createBrokerFromLogicalSocket(ls);
             try {
-                await broker.sendReceiveAsync(new BrokerMessage.OutboundRequest('method', [])).
+                await broker.sendReceiveAsync(new BrokerMessage.OutboundRequest('ENDPOINT_NAME', 'method', [])).
                     should.be.eventually.rejected;
             } finally {
                 await broker.disposeAsync();

--- a/src/Clients/nodejs/test/unit/core-internals/context.test.ts
+++ b/src/Clients/nodejs/test/unit/core-internals/context.test.ts
@@ -21,9 +21,9 @@ function callData(partial: Partial<ICallContextData>): ICallContextData {
     return { ...partial, dispose() { } } as any;
 }
 
-const wireRequest = new WireMessage.Request(1, 'id', 'methodName', []);
+const wireRequest = new WireMessage.Request(1, 'ENDPOINT_NAME', 'id', 'methodName', []);
 const validCallData = callData({ cancellationToken: CancellationToken.none, wireRequest });
-const validCallDataFactory = (id: string) => callData({ cancellationToken: CancellationToken.none, wireRequest: new WireMessage.Request(1, id, 'methodName', []) });
+const validCallDataFactory = (id: string) => callData({ cancellationToken: CancellationToken.none, wireRequest: new WireMessage.Request(1, 'ENDPOINT_NAME', id, 'methodName', []) });
 
 describe(`core:internals -> class:CallContext`, () => {
     context(`ctor`, () => {

--- a/src/Clients/nodejs/test/unit/core-internals/message-stream.test.ts
+++ b/src/Clients/nodejs/test/unit/core-internals/message-stream.test.ts
@@ -73,7 +73,7 @@ describe(`core:internals -> class:MessageStream`, () => {
         });
 
         it(`should emit when there's data avaible`, async () => {
-            const sourceObj = new WireMessage.Request(1, 'id', 'methodName', ['1', 'true', 'null']);
+            const sourceObj = new WireMessage.Request(1, 'ENDPOINT_NAME', 'id', 'methodName', ['1', 'true', 'null']);
             const sourceJson = JSON.stringify(sourceObj);
             const sourceBufferPayload = Buffer.from(sourceJson, 'utf-8');
             const sourceBufferCb = Buffer.alloc(4);
@@ -127,7 +127,7 @@ describe(`core:internals -> class:MessageStream`, () => {
             (mock as any).writeAsync = spy(() => { });
 
             const messageStream = new MessageStream(mock);
-            messageStream.writeAsync(new WireMessage.Request(1, 'id', 'methodName', []), CancellationToken.none);
+            messageStream.writeAsync(new WireMessage.Request(1, 'ENDPOINT_NAME', 'id', 'methodName', []), CancellationToken.none);
             mock.writeAsync.should.have.been.called();
         });
     });

--- a/src/Clients/nodejs/test/unit/core-internals/serialization-pal.test.ts
+++ b/src/Clients/nodejs/test/unit/core-internals/serialization-pal.test.ts
@@ -458,7 +458,7 @@ describe(`core:internals -> class:SerializationPal`, () => {
         });
 
         it(`shouldn't throw provided a valid wireRequest`, () => {
-            const wireRequest = new WireMessage.Request(1, 'id', 'methodName', []);
+            const wireRequest = new WireMessage.Request(1, 'ENDPOINT_NAME', 'id', 'methodName', []);
             (() => SerializationPal.deserializeRequest(wireRequest)).should.not.throw();
         });
     });

--- a/src/Clients/nodejs/test/unit/core-surface/ipc-client.test.ts
+++ b/src/Clients/nodejs/test/unit/core-surface/ipc-client.test.ts
@@ -15,10 +15,43 @@ import { IBroker } from '../../../src/core/internals/broker';
 import { ArgumentNullError } from '../../../src/foundation/errors';
 import { PromiseCompletionSource, CancellationToken } from '../../../src/foundation/threading';
 import { IPipeClientStream } from '../../../src/foundation/pipes';
+import { Message } from '../../../src/core/surface/message';
+
 
 import * as BrokerMessage from '../../../src/core/internals/broker-message';
 
 describe(`core:surface -> class:IpcClient`, () => {
+    if (1 as any === 2) {
+        context(`temporary-e2e`, () => {
+            it(`should work`, async () => {
+
+                class IAlgebra {
+                    public Multiply(x: number, y: number, message: Message<void>): Promise<number> {
+                        throw null;
+                    }
+                }
+
+                interface IArithmetics {
+                    Sum(x: number, y: number): Promise<number>;
+                }
+
+                class Arithmetics implements IArithmetics {
+                    public async Sum(x: number, y: number): Promise<number> {
+                        return x + y;
+                    }
+                }
+
+                const client = new IpcClient('foobar', IAlgebra, x => {
+                    x.callbackService = new Arithmetics();
+                });
+                const result = await client.proxy.Multiply(5, 6, new Message<void>());
+
+                console.log(`result == ${result}`);
+
+            });
+        });
+    }
+
     context(`ctor`, () => {
         it(`should throw provided a falsy pipeName`, () => {
             (() => new IpcClient(null as any, Object)).should.throw(ArgumentNullError).with.property('paramName', 'pipeName');


### PR DESCRIPTION
- the Node.js library doesn't yet offer using multiple endpoints over the same connection
- the Node.js library is now compatible with .NET servers which don't offer backwards compatibility anymore
- the Node.js library is not backwards compatible with old .NET servers