### PR TITLE
nodejs: Allow the explicit overriding of endpoint names

### DIFF
--- a/src/Clients/nodejs/src/core/internals/broker.ts
+++ b/src/Clients/nodejs/src/core/internals/broker.ts
@@ -118,7 +118,7 @@ export class Broker implements IBroker, IAsyncDisposable {
 
         this._newConnection = true;
 
-        return result;
+        return result as any;
     }
 
     private processInboundAsync(event: MessageEvent): void {

--- a/src/Clients/nodejs/src/core/internals/proxy-factory.ts
+++ b/src/Clients/nodejs/src/core/internals/proxy-factory.ts
@@ -56,7 +56,8 @@ export class Generator<TService> {
     }
 
     private generateMethod(methodName: string): IMethod {
-        const maybeMethodInfo = rtti.ClassInfo.get(this._sampleCtor as any).tryGetMethod(methodName);
+        const classInfo = rtti.ClassInfo.get(this._sampleCtor as any);
+        const maybeMethodInfo = classInfo.tryGetMethod(methodName);
         const hasCancellationToken = maybeMethodInfo ? maybeMethodInfo.hasCancellationToken : false;
 
         const normalizeArgs = Normalizers.getArgListNormalizer(hasCancellationToken);
@@ -65,7 +66,7 @@ export class Generator<TService> {
 
         const traceCategory = this._traceCategory;
 
-        const endpointName = this._sampleCtor.name;
+        const endpointName = classInfo.maybeEndpointName || this._sampleCtor.name;
 
         return async function(this: IProxy) {
             traceCategory.log(`executing "${methodName}", stack is:\r\n${new StackTrace()}`);

--- a/src/Clients/nodejs/src/core/surface/rtti.ts
+++ b/src/Clients/nodejs/src/core/surface/rtti.ts
@@ -22,6 +22,12 @@ export function __returns__(returnValueCtor: PublicConstructor<unknown>) {
     };
 }
 
+export function __endpoint__(name: string) {
+    return (ctor: PublicConstructor<unknown>) => {
+        rtti.ClassInfo.get(ctor).maybeEndpointName = name;
+    };
+}
+
 /* @internal */
 export module rtti {
     export class ClassInfo<T> {
@@ -34,6 +40,7 @@ export module rtti {
             public readonly constructor: PublicConstructor<T>,
             public readonly prototype: any
         ) { }
+        public maybeEndpointName: string | null = null;
         public tryGetMethod(name: string): Maybe<MethodInfo<T>> { return this._methods[name] || null; }
         private [$classGetOrCreateMethod](name: string): MethodInfo<T> { return this._methods[name] || (this._methods[name] = new MethodInfo(this, name)); }
     }


### PR DESCRIPTION
- define a new class attribute `@__endpoint__ ` which allows specifying the CoreIpc endpoint name
- store the information provided by this attribute in the rtti store
- use the information from the rtti store in the ProxyGenerator

**without the attribute:**
```typescript
class IContract { /* methods here */ }
```
results in ` endpoint == "IContract" `

**with the attribute:**
```typescript
@__endpoint__('FooBar')
class IContract { /* methods here */ }
```
results in ` endpoint == "FooBar" `