### PR TITLE
nodejs: export the `@__endpoint__` attribute

### DIFF
--- a/src/Clients/nodejs/src/core/surface/index.ts
+++ b/src/Clients/nodejs/src/core/surface/index.ts
@@ -5,7 +5,7 @@ import {
     ConnectionFactoryDelegate
 } from './ipc-client';
 
-import { __hasCancellationToken__, __returns__ } from './rtti';
+import { __hasCancellationToken__, __returns__, __endpoint__ } from './rtti';
 import { Message } from './message';
 import { RemoteError } from './remote-error';
 
@@ -14,7 +14,7 @@ export {
     IIpcClientConfig,
     BeforeCallDelegate,
     ConnectionFactoryDelegate,
-    __hasCancellationToken__, __returns__,
+    __hasCancellationToken__, __returns__, __endpoint__,
     Message,
     RemoteError
 };

--- a/src/Clients/nodejs/src/index.ts
+++ b/src/Clients/nodejs/src/index.ts
@@ -9,7 +9,7 @@ import {
 } from './foundation/threading';
 
 import {
-    __hasCancellationToken__, __returns__,
+    __hasCancellationToken__, __returns__, __endpoint__,
     RemoteError,
     IpcClient,
     Message
@@ -37,5 +37,6 @@ export {
     IDisposable,
     __hasCancellationToken__,
     __returns__,
+    __endpoint__,
     Trace
 };


### PR DESCRIPTION
- define a new class attribute `@__endpoint__ ` which allows specifying the CoreIpc endpoint name
- store the information provided by this attribute in the rtti store
- use the information from the rtti store in the ProxyGenerator
- **export the `@__endpoint__` attribute**

**without the attribute:**
```typescript
class IContract { /* methods here */ }
```
results in ` endpoint == "IContract" `

**with the attribute:**
```typescript
@__endpoint__('FooBar')
class IContract { /* methods here */ }
```
results in ` endpoint == "FooBar" `