### PR TITLE
nodejs: fix e2e tests by locking the version of "DotNet-Script" to `0.50.1`

### DIFF
--- a/azp-nodejs.yaml
+++ b/azp-nodejs.yaml
@@ -4,7 +4,7 @@ steps:
     inputs:
       command: 'custom'
       custom: 'tool'
-      arguments: 'install -g dotnet-script'
+      arguments: 'install -g dotnet-script --version 0.50.1'
 
   - task: DotNetCoreCLI@2
     displayName: '$(Label_NodeJS) Check dotnet-script'

--- a/src/Clients/nodejs/test/unit/core-e2e/e2e.test.ts
+++ b/src/Clients/nodejs/test/unit/core-e2e/e2e.test.ts
@@ -68,9 +68,9 @@ public interface IAlgebra
 
 public sealed class Algebra : IAlgebra
 {
-    public async Task<int> MultiplySimple(int x, int y)
+    public Task<int> MultiplySimple(int x, int y)
     {
-        return x * y;
+        return Task.FromResult(x * y);
     }
 
     public async Task<int> Multiply(int x, int y, Message message = default)

--- a/src/Clients/nodejs/test/unit/core-e2e/e2e.test.ts
+++ b/src/Clients/nodejs/test/unit/core-e2e/e2e.test.ts
@@ -87,24 +87,29 @@ public sealed class Algebra : IAlgebra
     }
 }
 
-var services = new ServiceCollection();
+try {
+    Console.WriteLine("###STARTING###");
+    var services = new ServiceCollection();
 
-var sp = services
-    .AddLogging()
-    .AddIpc()
-    .AddSingleton<IAlgebra, Algebra>()
-    .BuildServiceProvider();
+    var sp = services
+        .AddLogging()
+        .AddIpc()
+        .AddSingleton<IAlgebra, Algebra>()
+        .BuildServiceProvider();
 
-var serviceHost = new ServiceHostBuilder(sp)
-    .UseNamedPipes(new NamedPipeSettings("foobar"))
-    .AddEndpoint<IAlgebra, IArithmetics>()
-    .Build();
+    var serviceHost = new ServiceHostBuilder(sp)
+        .UseNamedPipes(new NamedPipeSettings("foobar"))
+        .AddEndpoint<IAlgebra, IArithmetics>()
+        .Build();
 
-var thread = new AsyncContextThread();
-thread.Context.SynchronizationContext.Send(_ => Thread.CurrentThread.Name = "GuiThread", null);
-var sched = thread.Context.Scheduler;
-Console.WriteLine("###DONE###");
-await serviceHost.RunAsync(sched);
+    var thread = new AsyncContextThread();
+    thread.Context.SynchronizationContext.Send(_ => Thread.CurrentThread.Name = "GuiThread", null);
+    var sched = thread.Context.Scheduler;
+    Console.WriteLine("###DONE###");
+    await serviceHost.RunAsync(sched);
+} catch (Exception ex) {
+    Console.WriteLine($"Exception: {ex.GetType().Name}\\r\\nMessage: {ex.Message}\\r\\nStack: {ex.StackTrace}");
+}
 `;
     }
 

--- a/src/Clients/nodejs/test/unit/core-e2e/helpers/dotnet-script.ts
+++ b/src/Clients/nodejs/test/unit/core-e2e/helpers/dotnet-script.ts
@@ -78,13 +78,13 @@ export class DotNetScript implements IAsyncDisposable {
         });
         this._process.on('close', code => {
             if (this._awaiter) {
-                // this._awaiter(null);
+                this._awaiter(null);
             }
             if (this._process) {
-                // this._process.stdout.destroy();
+                this._process.stdout.destroy();
             }
-            // lineEmitter.emit('eof');
-            // lineEmitter.emit('line', null);
+            lineEmitter.emit('eof');
+            lineEmitter.emit('line', null);
             console.log('######## the child process ended with code', code);
         });
         this._stdin = this._process.stdin.setDefaultEncoding('utf-8');

--- a/src/Clients/nodejs/test/unit/core-e2e/helpers/dotnet-script.ts
+++ b/src/Clients/nodejs/test/unit/core-e2e/helpers/dotnet-script.ts
@@ -78,13 +78,13 @@ export class DotNetScript implements IAsyncDisposable {
         });
         this._process.on('close', code => {
             if (this._awaiter) {
-                this._awaiter(null);
+                // this._awaiter(null);
             }
             if (this._process) {
-                this._process.stdout.destroy();
+                // this._process.stdout.destroy();
             }
-            lineEmitter.emit('eof');
-            lineEmitter.emit('line', null);
+            // lineEmitter.emit('eof');
+            // lineEmitter.emit('line', null);
             console.log('######## the child process ended with code', code);
         });
         this._stdin = this._process.stdin.setDefaultEncoding('utf-8');


### PR DESCRIPTION
lock "DotNet-Script" to version `0.50.1`