### PR TITLE
Make one-way opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ WCF-like service model API for communication over named pipes. .NET Standard (.N
 - cancellation
 - timeouts
 - callbacks
-- one way calls (all methods that return non-generic `Task`)
+- one way calls
 - automatic reconnect
 - interception
 - configurable task scheduler

--- a/src/UiPath.CoreIpc.Tests/Implementation/ComputingService.cs
+++ b/src/UiPath.CoreIpc.Tests/Implementation/ComputingService.cs
@@ -40,11 +40,7 @@ namespace UiPath.CoreIpc.Tests
             return x + y;
         }
 
-        public async Task<bool> Infinite(CancellationToken cancellationToken = default)
-        {
-            await Task.Delay(Timeout.Infinite, cancellationToken);
-            return true;
-        }
+        public Task Infinite(CancellationToken cancellationToken = default) => Task.Delay(Timeout.Infinite, cancellationToken);
 
         public async Task<OneWay> InfiniteVoid(CancellationToken cancellationToken = default)
         {

--- a/src/UiPath.CoreIpc.Tests/Implementation/ComputingService.cs
+++ b/src/UiPath.CoreIpc.Tests/Implementation/ComputingService.cs
@@ -46,7 +46,11 @@ namespace UiPath.CoreIpc.Tests
             return true;
         }
 
-        public Task InfiniteVoid(CancellationToken cancellationToken = default) =>Task.Delay(Timeout.Infinite, cancellationToken);
+        public async Task<OneWay> InfiniteVoid(CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+            return OneWay.Instance;
+        }
 
         public async Task<string> SendMessage(SystemMessage message, CancellationToken cancellationToken = default)
         {

--- a/src/UiPath.CoreIpc.Tests/Implementation/IComputingService.cs
+++ b/src/UiPath.CoreIpc.Tests/Implementation/IComputingService.cs
@@ -34,7 +34,7 @@ namespace UiPath.CoreIpc.Tests
         Task<ComplexNumber> AddComplexNumbers(IEnumerable<ComplexNumber> numbers, CancellationToken cancellationToken = default);
         Task<string> SendMessage(SystemMessage message, CancellationToken cancellationToken = default);
         Task<bool> Infinite(CancellationToken cancellationToken = default);
-        Task InfiniteVoid(CancellationToken cancellationToken = default);
+        Task<OneWay> InfiniteVoid(CancellationToken cancellationToken = default);
         Task<string> GetCallbackThreadName(Message message = null, CancellationToken cancellationToken = default);
     }
 

--- a/src/UiPath.CoreIpc.Tests/Implementation/IComputingService.cs
+++ b/src/UiPath.CoreIpc.Tests/Implementation/IComputingService.cs
@@ -33,7 +33,7 @@ namespace UiPath.CoreIpc.Tests
         Task<ComplexNumber> AddComplexNumber(ComplexNumber x, ComplexNumber y, CancellationToken cancellationToken = default);
         Task<ComplexNumber> AddComplexNumbers(IEnumerable<ComplexNumber> numbers, CancellationToken cancellationToken = default);
         Task<string> SendMessage(SystemMessage message, CancellationToken cancellationToken = default);
-        Task<bool> Infinite(CancellationToken cancellationToken = default);
+        Task Infinite(CancellationToken cancellationToken = default);
         Task<OneWay> InfiniteVoid(CancellationToken cancellationToken = default);
         Task<string> GetCallbackThreadName(Message message = null, CancellationToken cancellationToken = default);
     }

--- a/src/UiPath.CoreIpc.Tests/Implementation/ISystemService.cs
+++ b/src/UiPath.CoreIpc.Tests/Implementation/ISystemService.cs
@@ -7,9 +7,9 @@ namespace UiPath.CoreIpc.Tests
 {
     public interface ISystemService
     {
-        Task DoNothing(CancellationToken cancellationToken = default);
-        Task VoidThreadName(CancellationToken cancellationToken = default);
-        Task VoidSyncThrow(CancellationToken cancellationToken = default);
+        Task<OneWay> DoNothing(CancellationToken cancellationToken = default);
+        Task<OneWay> VoidThreadName(CancellationToken cancellationToken = default);
+        Task<OneWay> VoidSyncThrow(CancellationToken cancellationToken = default);
         Task<string> GetThreadName(CancellationToken cancellationToken = default);
         Task<string> ConvertText(string text, TextStyle style, CancellationToken cancellationToken = default);
         Task<Guid> GetGuid(Guid guid, CancellationToken cancellationToken = default);

--- a/src/UiPath.CoreIpc.Tests/Implementation/ISystemService.cs
+++ b/src/UiPath.CoreIpc.Tests/Implementation/ISystemService.cs
@@ -14,9 +14,9 @@ namespace UiPath.CoreIpc.Tests
         Task<string> ConvertText(string text, TextStyle style, CancellationToken cancellationToken = default);
         Task<Guid> GetGuid(Guid guid, CancellationToken cancellationToken = default);
         Task<byte[]> ReverseBytes(byte[] input, CancellationToken cancellationToken = default);
-        Task<bool> SlowOperation(CancellationToken cancellationToken = default);
+        Task SlowOperation(CancellationToken cancellationToken = default);
         Task<string> MissingCallback(SystemMessage message, CancellationToken cancellationToken = default);
-        Task<bool> Infinite(CancellationToken cancellationToken = default);
+        Task Infinite(CancellationToken cancellationToken = default);
         Task<string> ImpersonateCaller(Message message = null, CancellationToken cancellationToken = default);
         Task<string> SendMessage(SystemMessage message, CancellationToken cancellationToken = default);
     }

--- a/src/UiPath.CoreIpc.Tests/Implementation/SystemService.cs
+++ b/src/UiPath.CoreIpc.Tests/Implementation/SystemService.cs
@@ -44,10 +44,11 @@ namespace UiPath.CoreIpc.Tests
 
         public bool DidNothing { get; set; }
 
-        public async Task DoNothing(CancellationToken cancellationToken = default)
+        public async Task<OneWay> DoNothing(CancellationToken cancellationToken = default)
         {
             await Task.Delay(1);
             DidNothing = true;
+            return OneWay.Instance;
         }
 
         public async Task<Guid> GetGuid(Guid guid, CancellationToken cancellationToken = default)
@@ -114,9 +115,13 @@ namespace UiPath.CoreIpc.Tests
 
         public string ThreadName;
 
-        public Task VoidSyncThrow(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<OneWay> VoidSyncThrow(CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-        public async Task VoidThreadName(CancellationToken cancellationToken = default) => ThreadName = Thread.CurrentThread.Name;
+        public async Task<OneWay> VoidThreadName(CancellationToken cancellationToken = default)
+        {
+            ThreadName = Thread.CurrentThread.Name;
+            return OneWay.Instance;
+        }
 
         public async Task<string> GetThreadName(CancellationToken cancellationToken = default) => Thread.CurrentThread.Name;
 

--- a/src/UiPath.CoreIpc.Tests/Implementation/SystemService.cs
+++ b/src/UiPath.CoreIpc.Tests/Implementation/SystemService.cs
@@ -13,11 +13,7 @@ namespace UiPath.CoreIpc.Tests
         {
         }
 
-        public async Task<bool> Infinite(CancellationToken cancellationToken = default)
-        {
-            await Task.Delay(Timeout.Infinite, cancellationToken);
-            return true;
-        }
+        public Task Infinite(CancellationToken cancellationToken = default) => Task.Delay(Timeout.Infinite, cancellationToken);
 
         public async Task<string> ConvertText(string text, TextStyle style, CancellationToken cancellationToken = default)
         {
@@ -89,7 +85,7 @@ namespace UiPath.CoreIpc.Tests
             return client.GetUserName() +" " + domainName;
         }
 
-        public async Task<bool> SlowOperation(CancellationToken cancellationToken = default)
+        public async Task SlowOperation(CancellationToken cancellationToken = default)
         {
             Console.WriteLine("SlowOperation " + Thread.CurrentThread.Name);
             try
@@ -101,7 +97,6 @@ namespace UiPath.CoreIpc.Tests
                     if(cancellationToken.IsCancellationRequested)
                     {
                         Console.WriteLine("SlowOperation Cancelled.");
-                        return false;
                     }
                 }
             }
@@ -110,7 +105,6 @@ namespace UiPath.CoreIpc.Tests
                 Console.WriteLine(ex.ToString());
             }
             Console.WriteLine("SlowOperation finished. "+ (cancellationToken.IsCancellationRequested ? "cancelled " : "") + Thread.CurrentThread.Name);
-            return true;
         }
 
         public string ThreadName;

--- a/src/UiPath.CoreIpc/IOHelpers.cs
+++ b/src/UiPath.CoreIpc/IOHelpers.cs
@@ -17,6 +17,13 @@ using System.Threading.Tasks;
 
 namespace UiPath.CoreIpc
 {
+    public class OneWay
+    {
+        public static readonly OneWay Instance = new OneWay();
+        private OneWay()
+        {
+        }
+    }
     public static class IOHelpers
     {
         public static ReadOnlyDictionary<TKey, TValue> ToReadOnlyDictionary<TKey, TValue>(this IDictionary<TKey, TValue> dictionary) => new ReadOnlyDictionary<TKey, TValue>(dictionary);

--- a/src/UiPath.CoreIpc/Server/Server.cs
+++ b/src/UiPath.CoreIpc/Server/Server.cs
@@ -118,9 +118,8 @@ namespace UiPath.CoreIpc
         }
         private async Task<Response> InvokeMethod(EndpointSettings endpoint, Request request, object service, MethodInfo method, object[] arguments)
         {
-            var isOneWay = method.ReturnType == typeof(Task<OneWay>);
             var methodCallTask = Task.Factory.StartNew(MethodCall, default, TaskCreationOptions.DenyChildAttach, endpoint.Scheduler ?? TaskScheduler.Default);
-            if (isOneWay)
+            if (method.ReturnType == typeof(Task<OneWay>))
             {
                 methodCallTask.Unwrap().LogException(Logger, method);
                 return Response.Success(request, "");


### PR DESCRIPTION
Another option would be to allow `void` methods. But I guess that would mean no errors whatsoever, including transport failures.