### PR TITLE
JsonSerializer: use DefaultValueHandling.IgnoreAndPopulate

### DIFF
--- a/src/UiPath.CoreIpc.Tests/Implementation/ComputingService.cs
+++ b/src/UiPath.CoreIpc.Tests/Implementation/ComputingService.cs
@@ -77,6 +77,14 @@ namespace UiPath.CoreIpc.Tests
         TitleCase,
         Upper
     }
+
+    public class ConvertTextArgs
+    {
+        public TextStyle TextStyle { get; set; } = TextStyle.Upper;
+
+        public string Text { get; set; } = string.Empty;
+    }
+
     public class ComputingService : IComputingService
     {
         private readonly ILogger<ComputingService> _logger;

--- a/src/UiPath.CoreIpc.Tests/Implementation/SystemService.cs
+++ b/src/UiPath.CoreIpc.Tests/Implementation/SystemService.cs
@@ -16,6 +16,7 @@ namespace UiPath.CoreIpc.Tests
         Task VoidSyncThrow(CancellationToken cancellationToken = default);
         Task<string> GetThreadName(CancellationToken cancellationToken = default);
         Task<string> ConvertText(string text, TextStyle style, CancellationToken cancellationToken = default);
+        Task<string> ConvertTextWithArgs(ConvertTextArgs args, CancellationToken cancellationToken = default);
         Task<Guid> GetGuid(Guid guid, CancellationToken cancellationToken = default);
         Task<byte[]> ReverseBytes(byte[] input, CancellationToken cancellationToken = default);
         Task<bool> SlowOperation(CancellationToken cancellationToken = default);
@@ -45,6 +46,8 @@ namespace UiPath.CoreIpc.Tests
             await Task.Delay(Timeout.Infinite, cancellationToken);
             return true;
         }
+        public async Task<string> ConvertTextWithArgs(ConvertTextArgs args, CancellationToken cancellationToken = default)
+            => await ConvertText(args.Text, args.TextStyle, cancellationToken);
 
         public async Task<string> ConvertText(string text, TextStyle style, CancellationToken cancellationToken = default)
         {

--- a/src/UiPath.CoreIpc.Tests/SystemTests.cs
+++ b/src/UiPath.CoreIpc.Tests/SystemTests.cs
@@ -95,6 +95,14 @@ namespace UiPath.CoreIpc.Tests
         }
 
         [Fact]
+        public async Task PropertyWithTypeDefaultValue()
+        {
+            var args = new ConvertTextArgs { Text = "hEllO woRd!", TextStyle = default };
+            var text = await _systemClient.ConvertTextWithArgs(args);
+            text.ShouldBe("Hello Word!");
+        }
+
+        [Fact]
         public async Task MaxMessageSize()
         {
             _systemClient.ReverseBytes(new byte[MaxReceivedMessageSizeInMegabytes * 1024 * 1024]).ShouldThrow<Exception>();

--- a/src/UiPath.CoreIpc/IpcJsonSerializer.cs
+++ b/src/UiPath.CoreIpc/IpcJsonSerializer.cs
@@ -20,7 +20,7 @@ namespace UiPath.CoreIpc
     class IpcJsonSerializer : ISerializer, IArrayPool<char>
     {
         static readonly JsonLoadSettings LoadSettings = new(){ LineInfoHandling = LineInfoHandling.Ignore };
-        static readonly JsonSerializer DefaultSerializer = new(){ DefaultValueHandling = DefaultValueHandling.Ignore, NullValueHandling = NullValueHandling.Ignore, 
+        static readonly JsonSerializer DefaultSerializer = new(){ DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate, NullValueHandling = NullValueHandling.Ignore, 
             CheckAdditionalContent = true };
 #if !NET461
         [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]


### PR DESCRIPTION
This fixes a case where a property is not serialized correctly if:
- has the type default value set on the instance that is serialized
- has a default value set in the class definition other than the type default value