### PR TITLE
Add tests for default values UI-53293

### DIFF
--- a/src/Clients/nodejs/dotnet/UiPath.CoreIpc.NodeInterop/Contracts.cs
+++ b/src/Clients/nodejs/dotnet/UiPath.CoreIpc.NodeInterop/Contracts.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using System.Threading;
 using System;
+using static UiPath.CoreIpc.NodeInterop.ServiceImpls;
 
 namespace UiPath.CoreIpc.NodeInterop
 {
@@ -36,6 +37,11 @@ namespace UiPath.CoreIpc.NodeInterop
         public interface IEnvironmentVariableGetter
         {
             Task<string?> Get(string variable);
+        }
+
+        public interface IDto
+        {
+            public Dto ReturnDto(Dto myDto);
         }
     }
 }

--- a/src/Clients/nodejs/dotnet/UiPath.CoreIpc.NodeInterop/Contracts.cs
+++ b/src/Clients/nodejs/dotnet/UiPath.CoreIpc.NodeInterop/Contracts.cs
@@ -10,6 +10,7 @@ namespace UiPath.CoreIpc.NodeInterop
         public interface IArithmetics
         {
             Task<int> Sum(int x, int y);
+            Task<bool> SendMessage(Message<int> message);
         }
 
         public interface IAlgebra
@@ -20,6 +21,7 @@ namespace UiPath.CoreIpc.NodeInterop
             Task<bool> Sleep(int milliseconds, Message message = default, CancellationToken ct = default);
             Task<bool> Timeout();
             Task<int> Echo(int x);
+            Task<bool> TestMessage(Message<int> message);
         }
 
         public interface ICalculus
@@ -39,9 +41,23 @@ namespace UiPath.CoreIpc.NodeInterop
             Task<string?> Get(string variable);
         }
 
-        public interface IDto
+        public interface IDtoService
         {
-            public Dto ReturnDto(Dto myDto);
+            Task<Dto> ReturnDto(Dto dto);
         }
+        public class Dto
+        {
+            public bool BoolProperty { get; set; }
+            public int IntProperty { get; set; }
+            public string StringProperty { get; set; }
+
+            public Dto(bool boolProperty, int intProperty, string stringProperty)
+            {
+                BoolProperty = boolProperty;
+                IntProperty = intProperty;
+                StringProperty = stringProperty;
+            }
+        }
+
     }
 }

--- a/src/Clients/nodejs/dotnet/UiPath.CoreIpc.NodeInterop/Program.cs
+++ b/src/Clients/nodejs/dotnet/UiPath.CoreIpc.NodeInterop/Program.cs
@@ -70,7 +70,7 @@ namespace UiPath.CoreIpc.NodeInterop
                 .AddSingleton<ICalculus, Calculus>()
                 .AddSingleton<IBrittleService, BrittleService>()
                 .AddSingleton<IEnvironmentVariableGetter, EnvironmentVariableGetter>()
-                .AddSingleton<IDto, Dto>()
+                .AddSingleton<IDtoService, DtoService>()
                 .BuildServiceProvider();
 
             var serviceHost = new ServiceHostBuilder(sp)
@@ -79,7 +79,7 @@ namespace UiPath.CoreIpc.NodeInterop
                 .AddEndpoint<ICalculus>()
                 .AddEndpoint<IBrittleService>()
                 .AddEndpoint<IEnvironmentVariableGetter>()
-                .AddEndpoint<IDto>()
+                .AddEndpoint<IDtoService>()
                 .Build();
 
             var thread = new AsyncContextThread();

--- a/src/Clients/nodejs/dotnet/UiPath.CoreIpc.NodeInterop/Program.cs
+++ b/src/Clients/nodejs/dotnet/UiPath.CoreIpc.NodeInterop/Program.cs
@@ -70,6 +70,7 @@ namespace UiPath.CoreIpc.NodeInterop
                 .AddSingleton<ICalculus, Calculus>()
                 .AddSingleton<IBrittleService, BrittleService>()
                 .AddSingleton<IEnvironmentVariableGetter, EnvironmentVariableGetter>()
+                .AddSingleton<IDto, Dto>()
                 .BuildServiceProvider();
 
             var serviceHost = new ServiceHostBuilder(sp)
@@ -78,6 +79,7 @@ namespace UiPath.CoreIpc.NodeInterop
                 .AddEndpoint<ICalculus>()
                 .AddEndpoint<IBrittleService>()
                 .AddEndpoint<IEnvironmentVariableGetter>()
+                .AddEndpoint<IDto>()
                 .Build();
 
             var thread = new AsyncContextThread();

--- a/src/Clients/nodejs/dotnet/UiPath.CoreIpc.NodeInterop/ServiceImpls.cs
+++ b/src/Clients/nodejs/dotnet/UiPath.CoreIpc.NodeInterop/ServiceImpls.cs
@@ -27,6 +27,11 @@ namespace UiPath.CoreIpc.NodeInterop
 
                 return result;
             }
+            public async Task<bool> TestMessage(Message<int> message)
+            {
+                var arithmetics = message.GetCallback<IArithmetics>();
+                return await arithmetics.SendMessage(message);
+            }
 
             public async Task<bool> Sleep(int milliseconds, Message message = default, CancellationToken ct = default)
             {
@@ -70,9 +75,12 @@ namespace UiPath.CoreIpc.NodeInterop
             public Task<string?> Get(string variable) => Task.FromResult<string?>(Environment.GetEnvironmentVariable(variable));
         }
 
-        public class Dto : IDto
+        public sealed class DtoService : IDtoService
         {
-            public Dto ReturnDto(Dto myDto) => myDto;
+            public Task<Dto> ReturnDto(Dto myDto)
+            {
+                return Task.FromResult(myDto);
+            }
         }
     }
 }

--- a/src/Clients/nodejs/dotnet/UiPath.CoreIpc.NodeInterop/ServiceImpls.cs
+++ b/src/Clients/nodejs/dotnet/UiPath.CoreIpc.NodeInterop/ServiceImpls.cs
@@ -69,5 +69,10 @@ namespace UiPath.CoreIpc.NodeInterop
         {
             public Task<string?> Get(string variable) => Task.FromResult<string?>(Environment.GetEnvironmentVariable(variable));
         }
+
+        public class Dto : IDto
+        {
+            public Dto ReturnDto(Dto myDto) => myDto;
+        }
     }
 }

--- a/src/Clients/nodejs/src/core/ipc/dtos/Message.ts
+++ b/src/Clients/nodejs/src/core/ipc/dtos/Message.ts
@@ -2,7 +2,7 @@
 
 import { TimeSpan, Timeout } from '../../../foundation';
 
-export class Message<T = void> {
+export class Message<T = number> {
     constructor(args?: {
         payload?: T,
         requestTimeout?: TimeSpan,

--- a/src/Clients/nodejs/test/unit/surface/core/Dto.ts
+++ b/src/Clients/nodejs/test/unit/surface/core/Dto.ts
@@ -1,0 +1,9 @@
+export class Dto {
+    constructor(
+    public readonly BoolProperty: boolean,
+    public readonly IntProperty: number,
+    public readonly StringProperty: string | null,
+    ) {}
+
+    public async ReturnDto(myDto: Dto): Promise<Dto> { return myDto; }
+}

--- a/src/UiPath.CoreIpc/IpcJsonSerializer.cs
+++ b/src/UiPath.CoreIpc/IpcJsonSerializer.cs
@@ -22,7 +22,7 @@ namespace UiPath.CoreIpc
         static readonly JsonLoadSettings LoadSettings = new(){ LineInfoHandling = LineInfoHandling.Ignore };
         static readonly JsonSerializer DefaultSerializer = new(){ DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate, NullValueHandling = NullValueHandling.Ignore, 
             CheckAdditionalContent = true };
-        static readonly JsonSerializer StringArgsSerializer = new(){ NullValueHandling = NullValueHandling.Ignore, CheckAdditionalContent = true };
+        static readonly JsonSerializer StringArgsSerializer = new(){ CheckAdditionalContent = true };
 #if !NET461
         [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
 #endif


### PR DESCRIPTION
Add coreipc tests with .NET default values (false, 0, null) directly as params and as members of DTO params.