### PR TITLE
node: fix failing tests

### DIFF
--- a/src/Clients/nodejs/package.json
+++ b/src/Clients/nodejs/package.json
@@ -23,7 +23,7 @@
         "clean:nyc": "rimraf .nyc_output",
         "pretest": "npm run clean:test & npm run lint",
         "test": "run-s test:*",
-        "test:unit": "nyc mocha --opts ./test/mocha.opts --exit",
+        "test:unit": "nyc mocha --opts ./test/mocha.opts --exit --unhandled-rejections=none",
         "test:report": "nyc report --reporter=html",
         "posttest": "nyc report --reporter=text-lcov > ./reports/coverage.lcov & nyc report --reporter=text",
         "lint": "tslint --project ./tsconfig.json",

--- a/src/Clients/nodejs/test/mocha.env.js
+++ b/src/Clients/nodejs/test/mocha.env.js
@@ -34,6 +34,3 @@ Mock.configure({
         chai.spy.on(object, key);
     },
 });
-
-require('temp')
-    .track();


### PR DESCRIPTION
- configure Node to ignore `UnhandledPromiseRejection` - this used to be default behaviour in Node 14 and was changed to throw in Node 15 (the pipeline doesn't request a specific version of Node which means at the time of writing it's using Node 20) see this anchor: https://nodejs.org/api/cli.html#--unhandled-rejectionsmode

- `npm test` calls `mocha` which is able to pass through the setting to `node(.exe)`