### PR TITLE
revert temporarily deactivated MSBuild condition and align CI and CD Node.js 

### DIFF
--- a/src/CI/azp-js.publish-npm.steps.yaml
+++ b/src/CI/azp-js.publish-npm.steps.yaml
@@ -5,10 +5,10 @@ steps:
   artifact: 'NPM package'
   # The destination path is $(Pipeline.Workspace)
 
-- task: NodeTool@0
-  displayName: 'Install Node.js 19.x'
+- task: NodeTool@0 
+  displayName: 'Use Node.js 20.11.0'
   inputs:
-    versionSpec: '19.x'
+    versionSpec: '20.11.0'
 
 - task: ExtractFiles@1
   displayName: 'Extract Files'

--- a/src/CI/azp-nodejs.yaml
+++ b/src/CI/azp-nodejs.yaml
@@ -4,6 +4,7 @@
       version: 6.0.x
 
   - task: NodeTool@0 
+    displayName: 'Use Node.js 20.11.0'
     inputs:
       versionSpec: '20.11.0'
     

--- a/src/UiPath.CoreIpc/UiPath.CoreIpc.csproj
+++ b/src/UiPath.CoreIpc/UiPath.CoreIpc.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net461;net6.0-windows</TargetFrameworks>
     <RootNamespace>UiPath.CoreIpc</RootNamespace>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild Condition="$(Configuration)=='Release'">true</GeneratePackageOnBuild>
     <Authors>UiPath</Authors>
     <Version>2.5.1</Version>
     <PackageProjectUrl>https://github.com/UiPath/CoreIpc/</PackageProjectUrl>


### PR DESCRIPTION
**dotnet**: revert the MSBuild condition that generated NuGet packages only in Release mode
**js**: align the Node.js SDK version to 20.11.0 between the CI and CD stages