### PR TITLE
add info in exception message about the message size when it is too large

### DIFF
--- a/src/UiPath.CoreIpc/Connection.cs
+++ b/src/UiPath.CoreIpc/Connection.cs
@@ -211,7 +211,7 @@ public sealed class Connection : IDisposable
                 var length = BitConverter.ToInt32(_buffer, startIndex: 1);
                 if (length > _maxMessageSize)
                 {
-                    throw new InvalidDataException($"Message too large. The maximum message size is {_maxMessageSize / (1024 * 1024)} megabytes.");
+                    throw new InvalidDataException($"Message too large ({length >> 20} MB). The maximum message size is {_maxMessageSize >> 20} MB.");
                 }
                 _nestedStream.Reset(length);
                 await HandleMessage();


### PR DESCRIPTION
we sometimes encounter this exception when debugging in Studio and it would help to know how large the failing message is.