### PR TITLE
Make properties mutable by changing init to set

### DIFF
--- a/src/UiPath.CoreIpc/Config/IpcClient.cs
+++ b/src/UiPath.CoreIpc/Config/IpcClient.cs
@@ -4,13 +4,13 @@ public sealed class IpcClient : IpcBase, IClientConfig
 {
     public ContractCollection? Callbacks { get; set; }
 
-    public ILogger? Logger { get; init; }
+    public ILogger? Logger { get; set; }
     public BeforeConnectHandler? BeforeConnect { get; set; }
     public BeforeCallHandler? BeforeOutgoingCall { get; set; }
 
     internal string DebugName { get; set; } = null!;
 
-    public required ClientTransport Transport { get; init; }
+    public required ClientTransport Transport { get; set; }
 
     string IClientConfig.GetComputedDebugName() => DebugName ?? Transport.ToString();
 

--- a/src/UiPath.CoreIpc/Config/IpcServer.cs
+++ b/src/UiPath.CoreIpc/Config/IpcServer.cs
@@ -4,8 +4,8 @@ namespace UiPath.Ipc;
 
 public sealed class IpcServer : IpcBase, IAsyncDisposable
 {
-    public required ContractCollection Endpoints { get; init; }
-    public required ServerTransport Transport { get; init; }
+    public required ContractCollection Endpoints { get; set; }
+    public required ServerTransport Transport { get; set; }
 
     private readonly object _lock = new();
     private readonly CancellationTokenSource _ctsActiveConnections = new();

--- a/src/UiPath.CoreIpc/Transport/NamedPipe/NamedPipeClientTransport.cs
+++ b/src/UiPath.CoreIpc/Transport/NamedPipe/NamedPipeClientTransport.cs
@@ -5,9 +5,9 @@ namespace UiPath.Ipc.Transport.NamedPipe;
 
 public record NamedPipeClientTransport : ClientTransport
 {
-    public required string PipeName { get; init; }
-    public string ServerName { get; init; } = ".";
-    public bool AllowImpersonation { get; init; }
+    public required string PipeName { get; set; }
+    public string ServerName { get; set; } = ".";
+    public bool AllowImpersonation { get; set; }
 
     public override string ToString() => $"ClientPipe={PipeName}";
 

--- a/src/UiPath.CoreIpc/Transport/NamedPipe/NamedPipeServerTransport.cs
+++ b/src/UiPath.CoreIpc/Transport/NamedPipe/NamedPipeServerTransport.cs
@@ -6,10 +6,10 @@ namespace UiPath.Ipc.Transport.NamedPipe;
 
 public sealed class NamedPipeServerTransport : ServerTransport
 {
-    public required string PipeName { get; init; }
-    public string ServerName { get; init; } = ".";
+    public required string PipeName { get; set; }
+    public string ServerName { get; set; } = ".";
     [JsonIgnore]
-    public AccessControlDelegate? AccessControl { get; init; }
+    public AccessControlDelegate? AccessControl { get; set; }
 
     internal override IServerState CreateServerState()
     => new ServerState { Transport = this };

--- a/src/UiPath.CoreIpc/Transport/Tcp/TcpClientTransport.cs
+++ b/src/UiPath.CoreIpc/Transport/Tcp/TcpClientTransport.cs
@@ -4,7 +4,7 @@ namespace UiPath.Ipc.Transport.Tcp;
 
 public sealed record TcpClientTransport : ClientTransport
 {
-    public required IPEndPoint EndPoint { get; init; }
+    public required IPEndPoint EndPoint { get; set; }
 
     public override string ToString() => $"TcpClient={EndPoint}";
 

--- a/src/UiPath.CoreIpc/Transport/Tcp/TcpServerTransport.cs
+++ b/src/UiPath.CoreIpc/Transport/Tcp/TcpServerTransport.cs
@@ -5,7 +5,7 @@ namespace UiPath.Ipc.Transport.Tcp;
 
 public sealed class TcpServerTransport : ServerTransport
 {
-    public required IPEndPoint EndPoint { get; init; }
+    public required IPEndPoint EndPoint { get; set; }
 
     internal override IServerState CreateServerState()
     {

--- a/src/UiPath.CoreIpc/Transport/WebSocket/WebSocketClientTransport.cs
+++ b/src/UiPath.CoreIpc/Transport/WebSocket/WebSocketClientTransport.cs
@@ -4,7 +4,7 @@ namespace UiPath.Ipc.Transport.WebSocket;
 
 public sealed record WebSocketClientTransport : ClientTransport
 {
-    public required Uri Uri { get; init; }
+    public required Uri Uri { get; set; }
     public override string ToString() => $"WebSocketClient={Uri}";
 
     internal override IClientState CreateState() => new WebSocketClientState();

--- a/src/UiPath.CoreIpc/Transport/WebSocket/WebSocketServerTransport.cs
+++ b/src/UiPath.CoreIpc/Transport/WebSocket/WebSocketServerTransport.cs
@@ -2,7 +2,7 @@
 
 public sealed class WebSocketServerTransport : ServerTransport
 {
-    public required Accept Accept { get; init; }
+    public required Accept Accept { get; set; }
 
     internal override IServerState CreateServerState() => new State { Transport = this };
 


### PR DESCRIPTION
Updated multiple classes to change properties from `init` to `set`, allowing for post-initialization modifications. This change affects the `Logger`, `Transport`, and various transport-related properties in `IpcClient`, `IpcServer`, `NamedPipeClientTransport`, `NamedPipeServerTransport`, `TcpClientTransport`, `TcpServerTransport`, `WebSocketClientTransport`, and `WebSocketServerTransport`. This enhancement improves flexibility for dynamic updates to these configurations.