### PR TITLE
Make `IpcBase.Timeout` nullable

### DIFF
--- a/src/UiPath.CoreIpc/Client/ServiceClient.cs
+++ b/src/UiPath.CoreIpc/Client/ServiceClient.cs
@@ -53,7 +53,7 @@ internal abstract class ServiceClient : IDisposable
         {
             CancellationToken cancellationToken = default;
             TimeSpan messageTimeout = default;
-            TimeSpan clientTimeout = Config.RequestTimeout;
+            TimeSpan clientTimeout = Config.RequestTimeout.OrInfinite();
             Stream? uploadStream = null;
             var methodName = method.Name;
 

--- a/src/UiPath.CoreIpc/Config/IClientConfig.cs
+++ b/src/UiPath.CoreIpc/Config/IClientConfig.cs
@@ -3,7 +3,7 @@
 // Maybe decommission
 internal interface IClientConfig
 {
-    TimeSpan RequestTimeout { get; }
+    TimeSpan? RequestTimeout { get; }
     BeforeConnectHandler? BeforeConnect { get; }
     BeforeCallHandler? BeforeOutgoingCall { get; }
     ILogger? Logger { get; }

--- a/src/UiPath.CoreIpc/Config/IpcBase.cs
+++ b/src/UiPath.CoreIpc/Config/IpcBase.cs
@@ -2,7 +2,7 @@
 
 public abstract class IpcBase
 {
-    public TimeSpan RequestTimeout { get; set; } = Timeout.InfiniteTimeSpan;
+    public TimeSpan? RequestTimeout { get; set; }
     public IServiceProvider? ServiceProvider { get; set; }
     public TaskScheduler? Scheduler { get; set; }
 }

--- a/src/UiPath.CoreIpc/Config/IpcBase.cs
+++ b/src/UiPath.CoreIpc/Config/IpcBase.cs
@@ -2,6 +2,9 @@
 
 public abstract class IpcBase
 {
+    /// <summary>
+    /// The optional default timeout for all invocation requests. Leaving it or explicitly setting it to <c>null</c> has the same effect as setting it to <see cref="Timeout.InfiniteTimeSpan"/>.
+    /// </summary>
     public TimeSpan? RequestTimeout { get; set; }
     public IServiceProvider? ServiceProvider { get; set; }
     public TaskScheduler? Scheduler { get; set; }

--- a/src/UiPath.CoreIpc/Helpers/DefaultsExtensions.cs
+++ b/src/UiPath.CoreIpc/Helpers/DefaultsExtensions.cs
@@ -12,6 +12,8 @@ internal static class DefaultsExtensions
     public static ContractToSettingsMap OrDefault(this ContractToSettingsMap? map) => map ?? EmptyContractToSettingsMap;
     public static ContractCollection OrDefault(this ContractCollection? endpoints) => endpoints ?? new();
 
+    public static TimeSpan OrInfinite(this TimeSpan? timeout) => timeout ?? Timeout.InfiniteTimeSpan;
+
     public static Func<T>? MaybeCreateServiceFactory<T>(this IServiceProvider? serviceProvider) where T : class
     {
         if (serviceProvider is null)

--- a/src/UiPath.CoreIpc/Server/Server.cs
+++ b/src/UiPath.CoreIpc/Server/Server.cs
@@ -24,13 +24,13 @@ internal class Server
     private readonly IClient? _client;
     private readonly ConcurrentDictionary<string, PooledCancellationTokenSource> _requests = new();
 
-    private readonly TimeSpan _requestTimeout;
+    private readonly TimeSpan? _requestTimeout;
 
     private ILogger? Logger => _connection.Logger;
     private bool LogEnabled => _connection.LogEnabled;
     public string DebugName => _connection.DebugName;
 
-    public Server(Router router, TimeSpan requestTimeout, Connection connection, IClient? client = null)
+    public Server(Router router, TimeSpan? requestTimeout, Connection connection, IClient? client = null)
     {
         _router = router;
         _requestTimeout = requestTimeout;

--- a/src/UiPath.CoreIpc/Server/ServerConnection.cs
+++ b/src/UiPath.CoreIpc/Server/ServerConnection.cs
@@ -71,7 +71,7 @@ internal sealed class ServerConnection : IClient, IDisposable, IClientConfig
     }
 
     #region IServiceClientConfig 
-    TimeSpan IClientConfig.RequestTimeout => _ipcServer.RequestTimeout;
+    TimeSpan? IClientConfig.RequestTimeout => _ipcServer.RequestTimeout;
     BeforeConnectHandler? IClientConfig.BeforeConnect => null;
     BeforeCallHandler? IClientConfig.BeforeOutgoingCall => null;
     ILogger? IClientConfig.Logger => _logger;

--- a/src/UiPath.CoreIpc/Wire/Dtos.cs
+++ b/src/UiPath.CoreIpc/Wire/Dtos.cs
@@ -23,7 +23,9 @@ internal record Request(string Endpoint, string Id, string MethodName, string[] 
 
     public override string ToString() => $"{Endpoint} {MethodName} {Id}.";
 
-    public  TimeSpan GetTimeout(TimeSpan defaultTimeout) => TimeoutInSeconds == 0 ? defaultTimeout : TimeSpan.FromSeconds(TimeoutInSeconds);
+    public  TimeSpan GetTimeout(TimeSpan? defaultTimeout) => TimeoutInSeconds == 0 
+        ? defaultTimeout.OrInfinite() 
+        : TimeSpan.FromSeconds(TimeoutInSeconds);
 }
 record CancellationRequest(string RequestId);
 


### PR DESCRIPTION
- Updated various components to use nullable TimeSpan for timeout values. The `RequestTimeout` property in `IClientConfig` and `IpcBase` is now nullable, allowing for the absence of a timeout.
- Introduced `OrInfinite()` extension method to provide a default infinite timeout when needed. Adjusted related methods and constructors in `ServiceClient`, `Server`, and `Dtos` to accommodate these changes.