### PR TITLE
[ROBO-4988] Fix incomplete OCE suppression

### DIFF
--- a/src/UiPath.CoreIpc/Config/IpcServer.cs
+++ b/src/UiPath.CoreIpc/Config/IpcServer.cs
@@ -145,9 +145,10 @@ public sealed class IpcServer : IpcBase, IAsyncDisposable
                 var newConnection = await slot.AwaitConnection(ct);
                 _newConnection.OnNext(newConnection);
             }
-            catch (OperationCanceledException ex) when (ex.CancellationToken == ct)
+            catch (OperationCanceledException)
             {
                 await slot.DisposeAsync();
+                /// we don't notify the observer, as <see cref="OperationCanceledException"/> is expected
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Fix the overzealousness with which the OCE's CT was tested to be the proper one in order to suppress the OCE in the logs.
This however is never true on Linux for NamedPipes, because disposing the Stream is the only wait to stop WaitForConnection, which then throws OCE with `default(CancellationToken)`.