### PR TITLE
[ROBO-4985] RemoteException - Client StackTrace

### DIFF
--- a/src/UiPath.CoreIpc.Tests/ComputingTests.cs
+++ b/src/UiPath.CoreIpc.Tests/ComputingTests.cs
@@ -2,6 +2,7 @@
 using Nito.AsyncEx;
 using Nito.Disposables;
 using NSubstitute;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using UiPath.Ipc.Transport.NamedPipe;
@@ -257,6 +258,38 @@ public abstract class ComputingTests : SpyTestBase
             })
             .WhenAll();
     }
+
+
+    [Theory]
+    [InlineData(false, 
+        nameof(ComputingService.ServerFrame2),
+        nameof(ComputingService.ServerFrame1),
+        nameof(ClientFrame2),
+        nameof(ClientFrame1))]
+    [InlineData(true,
+        nameof(ComputingCallback.CallbackFrame2),
+        nameof(ComputingCallback.CallbackFrame1),
+        nameof(ComputingService.GatewayFrame2),
+        nameof(ComputingService.GatewayFrame1),
+        nameof(ClientFrame2),
+        nameof(ClientFrame1))]
+    public async Task RemoteExceptionStackTrace_ShouldAlsoIncludeRemoteCallerFrames(bool callGateway, params string[] expectedFrames)
+    {
+        var act = async () => await ClientFrame1(callGateway);
+        var exception = await act.ShouldThrowAsync<RemoteException>();
+
+        exception.StackTrace
+            .ShouldNotBeNull()
+            .Split('\n')
+            .ShouldPartiallyContainInOrder(expectedFrames);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private async Task ClientFrame1(bool callGateway) => await ClientFrame2(callGateway);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private async Task ClientFrame2(bool callGateway) => _ = await (callGateway ? Proxy.DivideByZeroGateway() : Proxy.DivideByZero());
+
 
     public abstract IAsyncDisposable? RandomTransportPair(out ServerTransport listener, out ClientTransport transport);
 

--- a/src/UiPath.CoreIpc.Tests/Helpers/ShouldlyHelpers.cs
+++ b/src/UiPath.CoreIpc.Tests/Helpers/ShouldlyHelpers.cs
@@ -131,7 +131,7 @@ internal static class ShouldlyHelpers
             }
         }
 
-        throw new ShouldAssertException($"Expected `{nameof(haystack)}` to contain the following items \r\n{string.Join("\r\n", needles)} in order. The actual contents are:\r\n{string.Join("\r\n", haystack)}");
+        throw new ShouldAssertException($"Expected `{nameof(haystack)}` to contain {string.Join("\r\n", needles)} partially and in order. First missing item is: {needles[expected]}");
 
         bool ConditionFulfilled() => expected >= needles.Count;
     }

--- a/src/UiPath.CoreIpc.Tests/Helpers/ShouldlyHelpers.cs
+++ b/src/UiPath.CoreIpc.Tests/Helpers/ShouldlyHelpers.cs
@@ -1,4 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace UiPath.Ipc.Tests;
 
@@ -75,7 +77,7 @@ internal static class ShouldlyHelpers
             throw new ShouldAssertException($"The task {taskExpression} should stall for at least {lease} but it completed faster.");
         }
         catch (OperationCanceledException ex) when (ex.CancellationToken == cts.Token)
-        {            
+        {
         }
     }
 
@@ -113,5 +115,24 @@ internal static class ShouldlyHelpers
     {
         await task;
         return value;
+    }
+
+    public static void ShouldPartiallyContainInOrder(this IEnumerable<string> haystack, IReadOnlyList<string> needles)
+    {
+        int expected = 0;
+        if (ConditionFulfilled()) { return; }
+
+        foreach (var candidate in haystack)
+        {
+            if (candidate.Contains(needles[expected]))
+            {
+                expected++;
+                if (ConditionFulfilled()) { return; }
+            }
+        }
+
+        throw new ShouldAssertException($"Expected `{nameof(haystack)}` to contain the following items \r\n{string.Join("\r\n", needles)} in order. The actual contents are:\r\n{string.Join("\r\n", haystack)}");
+
+        bool ConditionFulfilled() => expected >= needles.Count;
     }
 }

--- a/src/UiPath.CoreIpc.Tests/Services/ComputingCallback.cs
+++ b/src/UiPath.CoreIpc.Tests/Services/ComputingCallback.cs
@@ -7,5 +7,13 @@ public sealed class ComputingCallback : IComputingCallback
     public async Task<string> GetThreadName() => Thread.CurrentThread.Name!;
 
     public async Task<int> AddInts(int x, int y) => x + y;
+
+    public async Task<bool> DivideByZeroOnClient()
+    {
+        return await CallbackFrame1();
+    }
+
+    public async Task<bool> CallbackFrame1() => await CallbackFrame2();
+    public async Task<bool> CallbackFrame2() => throw new DivideByZeroException();
 }
 

--- a/src/UiPath.CoreIpc.Tests/Services/ComputingService.cs
+++ b/src/UiPath.CoreIpc.Tests/Services/ComputingService.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using System.Runtime.CompilerServices;
 
 namespace UiPath.Ipc.Tests;
 
@@ -67,4 +68,26 @@ public sealed class ComputingService(ILogger<ComputingService> logger) : IComput
     {
         return await m.Client.GetCallback<IComputingCallback>().GetThreadName();
     }
+
+    public async Task<bool> DivideByZero()
+    {
+        ServerFrame1();
+        return true;
+    }
+
+    public async Task<bool> DivideByZeroGateway(Message m = null!)
+    {
+        return await GatewayFrame1(m);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ServerFrame1() => ServerFrame2();
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ServerFrame2() => throw new DivideByZeroException();
+
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static async Task<bool> GatewayFrame1(Message m) => await GatewayFrame2(m);
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static async Task<bool> GatewayFrame2(Message m) => await m.Client.GetCallback<IComputingCallback>().DivideByZeroOnClient();
 }

--- a/src/UiPath.CoreIpc.Tests/Services/IComputingService.cs
+++ b/src/UiPath.CoreIpc.Tests/Services/IComputingService.cs
@@ -15,6 +15,8 @@ public interface IComputingService : IComputingServiceBase
     Task<int> MultiplyInts(int x, int y, Message message = null!);
     Task<string?> GetCallContext();
     Task<string> SendMessage(Message m = null!, CancellationToken ct = default);
+    Task<bool> DivideByZero();
+    Task<bool> DivideByZeroGateway(Message m = null);
 }
 
 public interface IComputingCallbackBase
@@ -25,6 +27,7 @@ public interface IComputingCallbackBase
 public interface IComputingCallback : IComputingCallbackBase
 {
     Task<string> GetThreadName();
+    Task<bool> DivideByZeroOnClient();
 }
 
 public interface IArithmeticCallback

--- a/src/UiPath.CoreIpc.Tests/Services/SystemService.cs
+++ b/src/UiPath.CoreIpc.Tests/Services/SystemService.cs
@@ -1,6 +1,6 @@
-﻿using Castle.Core;
-using System.Buffers;
+﻿using System.Buffers;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace UiPath.Ipc.Tests;

--- a/src/UiPath.CoreIpc.Tests/SystemTests.cs
+++ b/src/UiPath.CoreIpc.Tests/SystemTests.cs
@@ -1,6 +1,6 @@
 ﻿using AutoFixture;
-using AutoFixture.Xunit2;
 using Microsoft.Extensions.Hosting;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Channels;
 using Xunit.Abstractions;

--- a/src/UiPath.CoreIpc/Wire/Dtos.cs
+++ b/src/UiPath.CoreIpc/Wire/Dtos.cs
@@ -1,6 +1,7 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using Newtonsoft.Json;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.ExceptionServices;
 using System.Text;
-using Newtonsoft.Json;
 
 namespace UiPath.Ipc;
 
@@ -66,13 +67,27 @@ public record Error(string Message, string StackTrace, string Type, Error? Inner
 
 public class RemoteException : Exception
 {
+
     public RemoteException(Error error) : base(error.Message, error.InnerError == null ? null : new RemoteException(error.InnerError))
     {
         Type = error.Type;
-        StackTrace = error.StackTrace;
+        if (error.StackTrace is not null)
+        {
+            SetRemoteStackTrace(error.StackTrace);
+        }
     }
+#if NETCOREAPP
+    private void SetRemoteStackTrace(string stackTrace) => _ = ExceptionDispatchInfo.SetRemoteStackTrace(this, stackTrace);
+#else
+    private const string StackTraceSeparator = "--- End of stack trace from previous location ---";
+    private string? _remoteStackTrace = null;
+
+    private void SetRemoteStackTrace(string stackTrace) => _remoteStackTrace = stackTrace?.TrimEnd('\r', '\n') ?? "";
+    public override string StackTrace => _remoteStackTrace is null 
+        ? base.StackTrace
+        : $"{_remoteStackTrace}\r\n{StackTraceSeparator}\r\n{base.StackTrace}";
+#endif
     public string Type { get; }
-    public override string StackTrace { get; }
     public new RemoteException? InnerException => base.InnerException as RemoteException;
     public override string ToString()
     {

--- a/src/UiPath.CoreIpc/Wire/Dtos.cs
+++ b/src/UiPath.CoreIpc/Wire/Dtos.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ExceptionServices;
 using System.Text;
@@ -67,26 +68,22 @@ public record Error(string Message, string StackTrace, string Type, Error? Inner
 
 public class RemoteException : Exception
 {
+    private const string StackTraceSeparator = "--- End of stack trace from previous location ---";
+    private string? _remoteStackTrace = null;
 
     public RemoteException(Error error) : base(error.Message, error.InnerError == null ? null : new RemoteException(error.InnerError))
     {
         Type = error.Type;
         if (error.StackTrace is not null)
         {
-            SetRemoteStackTrace(error.StackTrace);
+            _remoteStackTrace = error.StackTrace.TrimEnd('\r', '\n');
         }
     }
-#if NETCOREAPP
-    private void SetRemoteStackTrace(string stackTrace) => _ = ExceptionDispatchInfo.SetRemoteStackTrace(this, stackTrace);
-#else
-    private const string StackTraceSeparator = "--- End of stack trace from previous location ---";
-    private string? _remoteStackTrace = null;
 
-    private void SetRemoteStackTrace(string stackTrace) => _remoteStackTrace = stackTrace?.TrimEnd('\r', '\n') ?? "";
-    public override string StackTrace => _remoteStackTrace is null 
+    public override string? StackTrace => _remoteStackTrace is null 
         ? base.StackTrace
         : $"{_remoteStackTrace}\r\n{StackTraceSeparator}\r\n{base.StackTrace}";
-#endif
+
     public string Type { get; }
     public new RemoteException? InnerException => base.InnerException as RemoteException;
     public override string ToString()


### PR DESCRIPTION
- Refactored `RemoteException` in `Dtos.cs` to handle stack traces differently for .NET Core and other frameworks.
- Implemented the `DivideByZero` operation in `SystemService` to test exceptions.
- Added `RemoteExceptionStackTrace_ShouldAlsoIncludeClientFrames` test to validate stack trace inclusion of client and server frames.
- Added `ShouldPartiallyContainInOrder` method in `ShouldlyHelpers.cs` for enumerable validation with logging.
- Removed unused namespaces and improved exception handling for clarity.