### PR TITLE
[ROBO-5356] Dispose channel 

### DIFF
--- a/src/Clients/js/src/std/bcl/collections/Dictionary.ts
+++ b/src/Clients/js/src/std/bcl/collections/Dictionary.ts
@@ -5,6 +5,10 @@ export class Dictionary<K, V> {
 
     private readonly _map = new Map<K, V>();
 
+    public get(key: K): V | undefined {
+        return this._map.get(key);
+    }
+
     public getOrCreateValue(key: K, factory: (key: K) => V): V {
         if (this._map.has(key)) {
             return this._map.get(key)!;
@@ -13,5 +17,17 @@ export class Dictionary<K, V> {
         let value = factory(key);
         this._map.set(key, value);
         return value;
+    }
+
+    public delete(key: K): boolean {
+        return this._map.delete(key);
+    }
+
+    public values(): IterableIterator<V> {
+        return this._map.values();
+    }
+
+    public clear(): void {
+        this._map.clear();
     }
 }

--- a/src/Clients/js/src/std/core/IpcBase.ts
+++ b/src/Clients/js/src/std/core/IpcBase.ts
@@ -30,6 +30,9 @@ export interface IpcBase<TAddressBuilder extends AddressBuilder> {
     readonly proxy: IpcBase.ProxySource<TAddressBuilder>;
     readonly config: IpcBase.Configuration<TAddressBuilder>;
     readonly callback: Callback<TAddressBuilder>;
+
+    disposeChannel(configure: AddressSelectionDelegate<TAddressBuilder>): Promise<void>;
+    disposeAllChannels(): Promise<void>;
 }
 
 export module IpcBase {
@@ -121,6 +124,15 @@ export abstract class IpcBaseImpl<TAddressBuilder extends AddressBuilder = any>
         const builder = new this.addressBuilder();
         configure(builder);
         return builder.assertAddress();
+    }
+
+    public async disposeChannel(configure: AddressSelectionDelegate<TAddressBuilder>): Promise<void> {
+        const address = this.getAddress(configure);
+        await this.wire.disposeChannel(address.key);
+    }
+
+    public async disposeAllChannels(): Promise<void> {
+        await this.wire.disposeAllChannels();
     }
 }
 

--- a/src/Clients/js/src/std/core/Protocol/Network/MessageStream.ts
+++ b/src/Clients/js/src/std/core/Protocol/Network/MessageStream.ts
@@ -39,7 +39,14 @@ export class MessageStream implements IMessageStream {
     }
     public async disposeAsync(): Promise<void> {
         this._ctsLoop.cancel();
-        await this._loop;
+
+        try {
+            await this._loop;
+        } catch (error) { 
+            if (!(error instanceof OperationCanceledError)) {
+                Trace.log(UnknownError.ensureError(error));
+            }
+        }
 
         this._stream.dispose();
     }

--- a/src/Clients/js/src/std/core/Protocol/Rpc/RpcChannel.ts
+++ b/src/Clients/js/src/std/core/Protocol/Rpc/RpcChannel.ts
@@ -6,6 +6,7 @@ import {
     ArgumentOutOfRangeError,
     SocketStream,
     UnknownError,
+    PromisePal,
 } from '../../../bcl';
 
 import { ConnectHelper, Address } from '../..';
@@ -80,7 +81,7 @@ export class RpcChannel implements IRpcChannel {
         );
 
         this._$messageStream.catch((_) => {
-            const __ = this.disposeAsync();
+            Trace.traceErrorNoThrow(this.disposeAsync());
         });
     }
 

--- a/src/Clients/js/src/std/core/Proxies/ChannelManager.ts
+++ b/src/Clients/js/src/std/core/Proxies/ChannelManager.ts
@@ -1,4 +1,4 @@
-import { CancellationToken, PublicCtor, Timeout, TimeSpan } from '../..';
+import { CancellationToken, IAsyncDisposable, PublicCtor, Timeout, TimeSpan } from '../..';
 
 import {
     IServiceProvider,
@@ -17,7 +17,7 @@ import { RpcRequestFactory } from '.';
 import { Observer } from 'rxjs';
 
 /* @internal */
-export class ChannelManager {
+export class ChannelManager implements IAsyncDisposable {
     private _latestChannel: IRpcChannel | undefined;
 
     constructor(
@@ -26,6 +26,15 @@ export class ChannelManager {
         private readonly _rpcChannelFactory: IRpcChannelFactory,
         private readonly _messageStreamFactory?: IMessageStream.Factory,
     ) {}
+
+    async disposeAsync(): Promise<void> {
+        const channel = this._latestChannel;
+        this._latestChannel = undefined;
+
+        if (channel && !channel.isDisposed) {
+            await channel.disposeAsync();
+        }
+    }
 
     async invokeMethod<TService>(service: PublicCtor<TService>, methodName: keyof TService & string, args: unknown[]): Promise<unknown> {
         const [rpcRequest, returnsPromiseOf, ct, timeout] = RpcRequestFactory.create(

--- a/src/Clients/js/src/std/core/Proxies/Wire.ts
+++ b/src/Clients/js/src/std/core/Proxies/Wire.ts
@@ -26,5 +26,20 @@ export class Wire {
                 this._messageStreamFactory));
     }
 
+    async disposeChannel(addressKey: string): Promise<void> {
+        const channelManager = this._map.get(addressKey);
+        if (channelManager) {
+            this._map.delete(addressKey);
+            await channelManager.disposeAsync();
+        }
+    }
+
+    async disposeAllChannels(): Promise<void> {
+        const channelManagers = [...this._map.values()];
+        this._map.clear();
+
+        await Promise.all(channelManagers.map(cm => cm.disposeAsync()));
+    }
+
     private readonly _map = new Dictionary<string, ChannelManager>();
 }

--- a/src/Clients/js/test/node/dispose.test.ts
+++ b/src/Clients/js/test/node/dispose.test.ts
@@ -1,0 +1,69 @@
+import { expect } from 'chai';
+import { ipc } from '../../src/node';
+import { IAlgebra } from './Contracts';
+import { AddressHelper as TestContext } from './Fixtures';
+
+describe('node:dispose', () => {
+    for (const context of [TestContext.WebSocket, TestContext.NamedPipe]) {
+
+        describe(`dispose with context: ${context}`, () => {
+            let algebraProxy: IAlgebra = null!;
+
+            beforeAll(() => {
+                algebraProxy = ipc.proxy.withAddress(context.address).withService(IAlgebra);
+            });
+
+            it('should work after disposeChannel', async () => {
+                // Make a call to establish a channel
+                const first = await algebraProxy.MultiplySimple(3, 4);
+                expect(first).to.equal(12);
+
+                // Dispose the channel
+                await ipc.disposeChannel(context.address);
+
+                // Make another call — should reconnect automatically
+                const second = await algebraProxy.MultiplySimple(5, 6);
+                expect(second).to.equal(30);
+            });
+
+            it('should work after disposeAllChannels', async () => {
+                const first = await algebraProxy.MultiplySimple(2, 7);
+                expect(first).to.equal(14);
+
+                await ipc.disposeAllChannels();
+
+                const second = await algebraProxy.MultiplySimple(3, 8);
+                expect(second).to.equal(24);
+            });
+
+            it('should survive multiple dispose-reconnect cycles', async () => {
+                for (let i = 1; i <= 3; i++) {
+                    const result = await algebraProxy.MultiplySimple(i, 10);
+                    expect(result).to.equal(i * 10);
+
+                    await ipc.disposeAllChannels();
+                }
+
+                // One final call after the last dispose
+                const final = await algebraProxy.MultiplySimple(9, 9);
+                expect(final).to.equal(81);
+            });
+
+            it('disposeChannel should be a no-op for an address with no open channel', async () => {
+                await ipc.disposeChannel(context.address);
+
+                // Subsequent call should still work
+                const result = await algebraProxy.MultiplySimple(4, 4);
+                expect(result).to.equal(16);
+            });
+
+            it('disposeAllChannels should be a no-op when no channels are open', async () => {
+                await ipc.disposeAllChannels();
+                await ipc.disposeAllChannels();
+
+                const result = await algebraProxy.MultiplySimple(6, 7);
+                expect(result).to.equal(42);
+            });
+        });
+    }
+});

--- a/src/Clients/js/test/std/core/dispose.test.ts
+++ b/src/Clients/js/test/std/core/dispose.test.ts
@@ -1,0 +1,299 @@
+import { Observer } from 'rxjs';
+
+import {
+    CancellationToken,
+    TimeSpan,
+    Wire,
+    ChannelManager,
+    ConfigStore,
+    ContractStore,
+    CallbackStoreImpl,
+    IRpcChannel,
+    IRpcChannelFactory,
+    IMessageStream,
+    RpcMessage,
+    RpcCallContext,
+    Address,
+    ConnectHelper,
+    Socket,
+} from '../../../src/std';
+
+import { NodeAddressBuilder } from '../../../src/node/NodeAddressBuilder';
+import { MockServiceProvider } from '../../infrastructure';
+
+import { expect } from 'chai';
+
+// --- Test doubles ---
+
+class MockAddress extends Address {
+    constructor(public readonly name: string) { super(); }
+    get key() { return `mock:${this.name}`; }
+    async connect(helper: ConnectHelper, timeout: TimeSpan, ct: CancellationToken): Promise<Socket> {
+        throw new Error('Should not be called in unit tests');
+    }
+}
+
+class MockRpcChannel implements IRpcChannel {
+    disposed = false;
+    callCount = 0;
+
+    get isDisposed() { return this.disposed; }
+
+    async disposeAsync(): Promise<void> {
+        this.disposed = true;
+    }
+
+    async call(request: RpcMessage.Request, timeout: TimeSpan, ct: CancellationToken): Promise<RpcMessage.Response> {
+        this.callCount++;
+        return new RpcMessage.Response(request.Id, JSON.stringify(null), null);
+    }
+}
+
+class MockRpcChannelFactory implements IRpcChannelFactory {
+    readonly channels: MockRpcChannel[] = [];
+
+    create(
+        address: Address,
+        connectHelper: ConnectHelper,
+        connectTimeout: TimeSpan,
+        ct: CancellationToken,
+        observer: Observer<RpcCallContext.Incomming>,
+        messageStreamFactory?: IMessageStream.Factory,
+    ): IRpcChannel {
+        const channel = new MockRpcChannel();
+        this.channels.push(channel);
+        return channel;
+    }
+}
+
+class MockService {
+    DoWork(): Promise<void> { throw void 0; }
+}
+
+function createMockServiceProvider() {
+    return new MockServiceProvider<NodeAddressBuilder>({
+        implementation: {
+            configStore: new ConfigStore<NodeAddressBuilder>(
+                new MockServiceProvider<NodeAddressBuilder>({
+                    implementation: {
+                        contractStore: new ContractStore(),
+                    },
+                }),
+            ),
+            contractStore: new ContractStore(),
+            callbackStore: new CallbackStoreImpl(),
+        },
+    });
+}
+
+// --- Tests ---
+
+describe('dispose', () => {
+
+    describe(`${ChannelManager.name}`, () => {
+        it('should dispose the underlying channel', async () => {
+            const factory = new MockRpcChannelFactory();
+            const sp = createMockServiceProvider();
+            const address = new MockAddress('pipe-1');
+            const cm = new ChannelManager(sp, address, factory);
+
+            // Trigger channel creation by invoking a method
+            await cm.invokeMethod(MockService, 'DoWork', []);
+            expect(factory.channels).to.have.lengthOf(1);
+
+            const channel = factory.channels[0];
+            expect(channel.disposed).to.equal(false);
+
+            await cm.disposeAsync();
+
+            expect(channel.disposed).to.equal(true);
+        });
+
+        it('should be a no-op when no channel was ever created', async () => {
+            const factory = new MockRpcChannelFactory();
+            const sp = createMockServiceProvider();
+            const address = new MockAddress('pipe-1');
+            const cm = new ChannelManager(sp, address, factory);
+
+            // Dispose without ever calling invokeMethod
+            await cm.disposeAsync();
+
+            expect(factory.channels).to.have.lengthOf(0);
+        });
+
+        it('should be a no-op when the channel is already disposed', async () => {
+            const factory = new MockRpcChannelFactory();
+            const sp = createMockServiceProvider();
+            const address = new MockAddress('pipe-1');
+            const cm = new ChannelManager(sp, address, factory);
+
+            await cm.invokeMethod(MockService, 'DoWork', []);
+            const channel = factory.channels[0];
+
+            // Pre-dispose the channel
+            await channel.disposeAsync();
+            expect(channel.disposed).to.equal(true);
+
+            // ChannelManager.disposeAsync should not throw
+            await cm.disposeAsync();
+        });
+
+        it('should create a new channel on next call after disposal', async () => {
+            const factory = new MockRpcChannelFactory();
+            const sp = createMockServiceProvider();
+            const address = new MockAddress('pipe-1');
+            const cm = new ChannelManager(sp, address, factory);
+
+            // First call creates channel #1
+            await cm.invokeMethod(MockService, 'DoWork', []);
+            expect(factory.channels).to.have.lengthOf(1);
+
+            const firstChannel = factory.channels[0];
+            expect(firstChannel.callCount).to.equal(1);
+
+            // Dispose the channel manager
+            await cm.disposeAsync();
+            expect(firstChannel.disposed).to.equal(true);
+
+            // Second call should create channel #2
+            await cm.invokeMethod(MockService, 'DoWork', []);
+            expect(factory.channels).to.have.lengthOf(2);
+
+            const secondChannel = factory.channels[1];
+            expect(secondChannel.callCount).to.equal(1);
+            expect(secondChannel.disposed).to.equal(false);
+        });
+    });
+
+    describe(`${Wire.name}`, () => {
+        it('disposeChannel should dispose and remove the channel for a specific address', async () => {
+            const factory = new MockRpcChannelFactory();
+            const sp = createMockServiceProvider();
+            const wire = new Wire(sp, factory);
+
+            const address = new MockAddress('pipe-1');
+            const proxyId = { service: MockService, address };
+
+            // Invoke to create a channel
+            await wire.invokeMethod(proxyId, 'DoWork', []);
+            expect(factory.channels).to.have.lengthOf(1);
+            expect(factory.channels[0].disposed).to.equal(false);
+
+            // Dispose the channel
+            await wire.disposeChannel(address.key);
+            expect(factory.channels[0].disposed).to.equal(true);
+        });
+
+        it('disposeChannel should be a no-op for an unknown address', async () => {
+            const factory = new MockRpcChannelFactory();
+            const sp = createMockServiceProvider();
+            const wire = new Wire(sp, factory);
+
+            // Should not throw
+            await wire.disposeChannel('mock:unknown');
+        });
+
+        it('disposeAllChannels should dispose every open channel', async () => {
+            const factory = new MockRpcChannelFactory();
+            const sp = createMockServiceProvider();
+            const wire = new Wire(sp, factory);
+
+            const addr1 = new MockAddress('pipe-1');
+            const addr2 = new MockAddress('pipe-2');
+
+            await wire.invokeMethod({ service: MockService, address: addr1 }, 'DoWork', []);
+            await wire.invokeMethod({ service: MockService, address: addr2 }, 'DoWork', []);
+            expect(factory.channels).to.have.lengthOf(2);
+
+            await wire.disposeAllChannels();
+
+            expect(factory.channels[0].disposed).to.equal(true);
+            expect(factory.channels[1].disposed).to.equal(true);
+        });
+
+        it('disposeAllChannels should be a no-op when no channels exist', async () => {
+            const factory = new MockRpcChannelFactory();
+            const sp = createMockServiceProvider();
+            const wire = new Wire(sp, factory);
+
+            // Should not throw
+            await wire.disposeAllChannels();
+        });
+
+        it('should create a new channel after disposeChannel', async () => {
+            const factory = new MockRpcChannelFactory();
+            const sp = createMockServiceProvider();
+            const wire = new Wire(sp, factory);
+
+            const address = new MockAddress('pipe-1');
+            const proxyId = { service: MockService, address };
+
+            // First call
+            await wire.invokeMethod(proxyId, 'DoWork', []);
+            expect(factory.channels).to.have.lengthOf(1);
+
+            // Dispose
+            await wire.disposeChannel(address.key);
+            expect(factory.channels[0].disposed).to.equal(true);
+
+            // Second call — should reconnect
+            await wire.invokeMethod(proxyId, 'DoWork', []);
+            expect(factory.channels).to.have.lengthOf(2);
+            expect(factory.channels[1].disposed).to.equal(false);
+            expect(factory.channels[1].callCount).to.equal(1);
+        });
+
+        it('should create new channels for all addresses after disposeAllChannels', async () => {
+            const factory = new MockRpcChannelFactory();
+            const sp = createMockServiceProvider();
+            const wire = new Wire(sp, factory);
+
+            const addr1 = new MockAddress('pipe-1');
+            const addr2 = new MockAddress('pipe-2');
+            const pid1 = { service: MockService, address: addr1 };
+            const pid2 = { service: MockService, address: addr2 };
+
+            // Create channels for both addresses
+            await wire.invokeMethod(pid1, 'DoWork', []);
+            await wire.invokeMethod(pid2, 'DoWork', []);
+            expect(factory.channels).to.have.lengthOf(2);
+
+            // Dispose all
+            await wire.disposeAllChannels();
+            expect(factory.channels[0].disposed).to.equal(true);
+            expect(factory.channels[1].disposed).to.equal(true);
+
+            // Reconnect both
+            await wire.invokeMethod(pid1, 'DoWork', []);
+            await wire.invokeMethod(pid2, 'DoWork', []);
+            expect(factory.channels).to.have.lengthOf(4);
+            expect(factory.channels[2].disposed).to.equal(false);
+            expect(factory.channels[3].disposed).to.equal(false);
+        });
+
+        it('should allow multiple dispose-reconnect cycles', async () => {
+            const factory = new MockRpcChannelFactory();
+            const sp = createMockServiceProvider();
+            const wire = new Wire(sp, factory);
+
+            const address = new MockAddress('pipe-1');
+            const proxyId = { service: MockService, address };
+
+            for (let cycle = 0; cycle < 3; cycle++) {
+                await wire.invokeMethod(proxyId, 'DoWork', []);
+                await wire.disposeAllChannels();
+            }
+
+            expect(factory.channels).to.have.lengthOf(3);
+            for (const ch of factory.channels) {
+                expect(ch.disposed).to.equal(true);
+                expect(ch.callCount).to.equal(1);
+            }
+
+            // One final call that stays open
+            await wire.invokeMethod(proxyId, 'DoWork', []);
+            expect(factory.channels).to.have.lengthOf(4);
+            expect(factory.channels[3].disposed).to.equal(false);
+        });
+    });
+});


### PR DESCRIPTION
Introduce `disposeChannel` and `disposeAllChannels` methods to `IpcBase`, `Wire`, and `ChannelManager` for explicit resource cleanup. Enhance `Dictionary` with `get`, `delete`, `values`, and `clear` methods. Add comprehensive tests to verify channel disposal, reconnection, and no-op scenarios, improving reliability and resource management for IPC infrastructure.