### PR TITLE
[ROBO-5747] fix: don't log failed-accept Error on server teardown

### DIFF
--- a/src/CI/azp-start.yaml
+++ b/src/CI/azp-start.yaml
@@ -1,6 +1,7 @@
 name: $(Date:yyyyMMdd)$(Rev:-rr)
 
 variables:
+  SCG_KILL_SWITCH: 'true' # Because our integration with the Aikido Safe Chain pipeline decorator (SGC rollout) is still buggy: https://uipath-product.slack.com/archives/CMCKWF5TR/p1780002214456709
   Label_Initialization: 'Initialization:'
   Label_DotNet: '.NET:'
   Label_NodeJS: 'node.js:'

--- a/src/UiPath.CoreIpc.Tests/AssemblyInfo.cs
+++ b/src/UiPath.CoreIpc.Tests/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+// Run the whole suite serialized (no cross-collection parallelism). Several
+// tests touch process-wide state — e.g. the System.Diagnostics.Trace listener
+// in NamedPipeSmokeTests.Teardown, and shared named-pipe/port resources — which
+// is unsafe under xUnit's default parallel execution.
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/src/UiPath.CoreIpc.Tests/NamedPipeSmokeTests.Teardown.cs
+++ b/src/UiPath.CoreIpc.Tests/NamedPipeSmokeTests.Teardown.cs
@@ -29,15 +29,14 @@ public sealed partial class NamedPipeSmokeTests
             // churning the accept slots, then tear the server down underneath them.
             for (int i = 0; i < 5; i++)
             {
-                var raw = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+                // `using` (not an explicit Dispose) is exception-safe; the
+                // scope-end dispose is still an abrupt OS handle close.
+                using var raw = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
                 await raw.ConnectAsync(5_000);
-                raw.Dispose(); // abrupt
             }
 
-            await Task.Delay(500); // let slots re-park in WaitForConnectionAsync
-        } // DisposeAsync cancels the accept loop while slots are parked
-
-        await Task.Delay(1000); // let teardown settle
+            await Task.Delay(Timeouts.Short); // let the accept slots re-park before teardown
+        } // DisposeAsync awaits the accept-loop teardown, so any OnError has fired by here
 
         capture.AcceptErrors.ShouldBeEmpty();
     }

--- a/src/UiPath.CoreIpc.Tests/NamedPipeSmokeTests.Teardown.cs
+++ b/src/UiPath.CoreIpc.Tests/NamedPipeSmokeTests.Teardown.cs
@@ -1,0 +1,73 @@
+using System.IO.Pipes;
+
+namespace UiPath.Ipc.Tests;
+
+public sealed partial class NamedPipeSmokeTests
+{
+    // Regression test for the accept-loop teardown noise: disposing an IpcServer
+    // tears down the idle named-pipe accept slots parked in WaitForConnectionAsync.
+    // That can surface as a non-OCE IOException ("Pipe is broken") which used to be
+    // reported via OnError -> Trace.TraceError("Failed to accept new connection...").
+    // A clean shutdown must NOT log that. Real named pipes + real OS clients killed
+    // abruptly (no mocks); captures the real System.Diagnostics.Trace error stream.
+    [Fact]
+    public async Task DisposingServerDoesNotLogFailedAcceptOnTeardown()
+    {
+        var pipeName = $"ipctest_{Guid.NewGuid():N}";
+        using var capture = new TraceErrorCapture();
+
+        await using (var ipcServer = CreateServer(pipeName))
+        {
+            ipcServer.Start();
+
+            // A real client establishes a working connection (accept loop cycles).
+            var ipcClient = CreateClient(pipeName);
+            await ipcClient.GetProxy<IComputingService>().AddFloats(2, 3).ShouldBeAsync(5);
+
+            // Simulate the executor being killed: connect real OS pipe clients and
+            // drop them abruptly (close the handle without a graceful disconnect),
+            // churning the accept slots, then tear the server down underneath them.
+            for (int i = 0; i < 5; i++)
+            {
+                var raw = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+                await raw.ConnectAsync(5_000);
+                raw.Dispose(); // abrupt
+            }
+
+            await Task.Delay(500); // let slots re-park in WaitForConnectionAsync
+        } // DisposeAsync cancels the accept loop while slots are parked
+
+        await Task.Delay(1000); // let teardown settle
+
+        capture.AcceptErrors.ShouldBeEmpty();
+    }
+
+    private sealed class TraceErrorCapture : TraceListener
+    {
+        private readonly List<string> _errors = new();
+
+        public TraceErrorCapture() => Trace.Listeners.Add(this);
+
+        public string[] AcceptErrors
+        {
+            get { lock (_errors) return _errors.Where(e => e.Contains("Failed to accept new connection")).ToArray(); }
+        }
+
+        public override void TraceEvent(TraceEventCache? eventCache, string source, TraceEventType eventType, int id, string? message)
+        {
+            if (eventType == TraceEventType.Error && message is not null)
+            {
+                lock (_errors) _errors.Add(message);
+            }
+        }
+
+        public override void Write(string? message) { }
+        public override void WriteLine(string? message) { }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) Trace.Listeners.Remove(this);
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/UiPath.CoreIpc/Config/IpcServer.cs
+++ b/src/UiPath.CoreIpc/Config/IpcServer.cs
@@ -134,7 +134,8 @@ public sealed class IpcServer : IpcBase, IAsyncDisposable
         /// <summary>
         /// This method returns when a new connection is accepted, or when cancellation or another error occurs.
         /// In case of cancellation or error, it will dispose of the underlying resources and will suppress the exception.
-        /// In case of an error (not a cancellation), it will notify the observer about the error.
+        /// In case of a genuine error it will notify the observer; an error that surfaces while cancellation is already
+        /// requested (a shutdown-race, e.g. a broken/disposed pipe) is treated as expected teardown and NOT reported.
         /// </summary>
         private async Task TryAccept(CancellationToken ct)
         {
@@ -153,7 +154,15 @@ public sealed class IpcServer : IpcBase, IAsyncDisposable
             catch (Exception ex)
             {
                 await slot.DisposeAsync();
-                _newConnection.OnError(ex);
+                // During shutdown the slot's pipe can break or be disposed and
+                // surface as a non-OCE exception (e.g. IOException "Pipe is
+                // broken") instead of an OperationCanceledException. That's
+                // expected teardown, not a failed accept — only report genuine
+                // (non-cancelled) errors to the observer.
+                if (!ct.IsCancellationRequested)
+                {
+                    _newConnection.OnError(ex);
+                }
             }
         }
 


### PR DESCRIPTION
## Outside the main goal of this PR:

🚨⚠️ Added a new variable **`SCG_KILL_SWITCH`** with the value **`'true'`**
to the **`azp-start.yaml`** file which disables the [Aikido Safe Chain](https://www.aikido.dev/blog/introducing-safe-chain) pipeline decorator (SCG rollout). This is due to a bug which we hope will be fixed soon: https://uipath-product.slack.com/archives/CMCKWF5TR/p1780002214456709

## Main changeset:

Disposing an IpcServer cancels the accept loop; on Linux a parked slot's pipe can surface as a non-OCE IOException ("Pipe is broken") rather than an OperationCanceledException, which was logged as "Failed to accept new connection". Suppress it when cancellation is already requested (genuine errors still log). Includes a real-pipe, Linux red->green regression test.

## Test Results (on CI-RobotIntegration-Test)

## PR #126 teardown-noise verification — coreipc `IpcServer` accept loop

Artifact: `RobotLogs` (per build). Search string in Robot.log: `Failed to accept new connection`
Full line (before fix): `Failed to accept new connection. Ex: System.IO.IOException: Pipe is broken.`

| Build | Fix? | Leg | File in RobotLogs/ | Matches | First 3 line #s |
|---|---|---|---|---|---|
| [12439546](https://uipath.visualstudio.com/Studio/_build/results?buildId=12439546&view=artifacts&pathToSelect=%2FRobotLogs&type=publishedArtifacts) | ✅ with fix | Linux: Build | `Robot.log` | **0** | — (no matches) |
| 12439546 | ✅ with fix | Docker: Linux | `Robot-*.log` | **0** | — (no matches) |
| 12439546 | ✅ with fix | Mac: Build | _stage still in progress — no logs published_ | n/a | — |
| 12439546 | ✅ with fix | Windows ×3 / Serverless | `Robot.log` | 0 | — |
| [12436764](https://uipath.visualstudio.com/Studio/_build/results?buildId=12436764&view=artifacts&pathToSelect=%2FRobotLogs&type=publishedArtifacts) | ❌ no fix | Linux: Build | `Robot.log` | **2675** | 2466, 2472, 2478 |
| 12436764 | ❌ no fix | Docker: Linux | `Robot-7f2da42b-c12b-4e07-8da5-247649cc0c57.log` | **2035** | 231, 237, 243 |
| 12436764 | ❌ no fix | Mac: Build | `Robot.log` | **3125** | 2513, 2519, 2525 |
| 12436764 | ❌ no fix | Windows ×3 / Serverless | `Robot.log` | 0 | — |

**How to verify:** open the file in the leg's RobotLogs zip, Find `Failed to accept new connection` →
before-fix legs hit it thousands of times (jump to the line #s above); fixed Linux/Docker legs return **0 matches**.
Noise is Unix-only (Windows = 0 in both), matching the root cause PR #126 guards.

## Test Results (on dev machine)  — 20 runs per cell (80 total)

| | Linux (WSL Debian, net6.0) | Windows (net6.0) |
|---|---|---|
| **with fix**    | ✅ 20 / 20 pass            | ✅ 20 / 20 pass |
| **without fix** | ❌ 0 / 20 fail (expected)   | ✅ 20 / 20 pass |

## Findings

- **Deterministic on Linux.** Without the fix the test fails on every run (20/20), reproducing
  the exact production stack trace (`IOException: Pipe is broken` at
  `NamedPipeServerTransport.AwaitConnection → IpcServer.Accepter.TryAccept`). With the fix it
  passes on every run. No flakiness in either direction.
- **Windows never manifests it** (20/20 pass with *and* without the fix). There the accept
  cancellation is a clean `OperationCanceledException` (already suppressed); the non-OCE
  `IOException` only leaks on the Linux dispose-based cancellation path. This matches the
  original report, which was Linux.

## How the Linux runs were executed

```bash
wsl -d Debian                       # default distro (docker-desktop) has no shell
cd /mnt/d/Code/coreipc
DOTNET_ROLL_FORWARD=Major \         # Debian has .NET 8/10 runtimes, not net6.0
  dotnet test src/UiPath.CoreIpc.Tests/UiPath.CoreIpc.Tests.csproj -f net6.0 \
  --filter "FullyQualifiedName~DisposingServerDoesNotLogFailedAcceptOnTeardown"
```

## Follow-up — addressed Copilot review (commit `8c52ee4`)

Three test-only nits from the Copilot review (the fix itself was unchanged):

- **Serialized the whole test suite** — `[assembly: CollectionBehavior(DisableTestParallelization = true)]`. The teardown test attaches a process-wide `System.Diagnostics.Trace` listener, which is unsafe under xUnit's default cross-collection parallelism; serializing removes the hazard entirely.
- **`using` on the raw `NamedPipeClientStream`** — exception-safe (no leak if `ConnectAsync` throws); the scope-end dispose is still an abrupt OS handle close.
- **Dropped the fixed `Task.Delay` sleeps** — `Timeouts.Short` for the slot re-park, and removed the post-dispose settle delay (`DisposeAsync` already awaits the accept-loop teardown, so any `OnError` has fired by then).

Re-verified with the new timings (Linux WSL/Debian, net6.0): **10/10 fail without the fix, 10/10 pass with it**; Windows still passes.
