### PR TITLE
[ROBO-5857] .NET: IpcContext ambient context - write callback-capable contracts without a Message parameter

### DIFF
--- a/src/UiPath.CoreIpc.Tests/IpcContextTests.cs
+++ b/src/UiPath.CoreIpc.Tests/IpcContextTests.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Logging;
+using UiPath.Ipc.Transport.NamedPipe;
+
+namespace UiPath.Ipc.Tests;
+
+// A POCO contract: no `Message` parameter, yet callback-capable via `IpcContext.Current`.
+public interface IContextProbe
+{
+    Task<string> ReachCallbackViaContext();
+    Task<bool> ContextIsSet();
+}
+
+public interface IContextProbeCallback
+{
+    Task<string> Pong();
+}
+
+public sealed class ContextProbe : IContextProbe
+{
+    public const string PongValue = "pong-from-callback";
+
+    // No Message parameter anywhere: the peer is reached through the ambient context.
+    public Task<string> ReachCallbackViaContext()
+        => IpcContext.Current!.GetCallback<IContextProbeCallback>().Pong();
+
+    public Task<bool> ContextIsSet() => Task.FromResult(IpcContext.Current is not null);
+}
+
+public sealed class ContextProbeCallback : IContextProbeCallback
+{
+    public Task<string> Pong() => Task.FromResult(ContextProbe.PongValue);
+}
+
+public sealed class IpcContextTests
+{
+    [Fact]
+    public void Current_IsNull_OutsideAnyIpcCall()
+        => IpcContext.Current.ShouldBeNull();
+
+    [Fact]
+    public async Task Current_IsSet_WhileHonoringACall()
+    {
+        await using var pair = await Pair.Create();
+        (await pair.Proxy.ContextIsSet()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task PocoContract_ReachesCallback_ViaIpcContext()
+    {
+        await using var pair = await Pair.Create();
+        (await pair.Proxy.ReachCallbackViaContext()).ShouldBe(ContextProbe.PongValue);
+    }
+
+    [Fact]
+    public async Task Current_IsNullAgain_AfterTheCallCompletes()
+    {
+        await using var pair = await Pair.Create();
+        await pair.Proxy.ContextIsSet();
+        // The ambient value must not leak into the test's own async flow.
+        IpcContext.Current.ShouldBeNull();
+    }
+
+    private sealed class Pair : IAsyncDisposable
+    {
+        private readonly IpcServer _server;
+        public IContextProbe Proxy { get; }
+
+        private Pair(IpcServer server, IContextProbe proxy)
+        {
+            _server = server;
+            Proxy = proxy;
+        }
+
+        public static async Task<Pair> Create()
+        {
+            var pipeName = $"ipctest_ctx_{Guid.NewGuid():N}";
+
+            var server = new IpcServer
+            {
+                Transport = new NamedPipeServerTransport { PipeName = pipeName },
+                Endpoints = new() { typeof(IContextProbe) },
+                ServiceProvider = new ServiceCollection()
+                    .AddLogging()
+                    .AddSingleton<IContextProbe, ContextProbe>()
+                    .BuildServiceProvider(),
+            };
+
+            var client = new IpcClient
+            {
+                Transport = new NamedPipeClientTransport { PipeName = pipeName },
+                Callbacks = new() { { typeof(IContextProbeCallback), new ContextProbeCallback() } },
+            };
+            var proxy = client.GetProxy<IContextProbe>();
+
+            server.Start();
+            await Task.Yield();
+            return new Pair(server, proxy);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            (Proxy as IpcProxy)?.Dispose();
+            await ((Proxy as IpcProxy)?.CloseConnection() ?? default);
+            await _server.DisposeAsync();
+        }
+    }
+}

--- a/src/UiPath.CoreIpc/IpcContext.cs
+++ b/src/UiPath.CoreIpc/IpcContext.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Threading;
+
+namespace UiPath.Ipc;
+
+/// <summary>Ambient context of the IPC call being honored, letting a POCO contract reach
+/// the peer without a <see cref="Message"/> parameter. Coexists with <see cref="Message"/>.</summary>
+public sealed class IpcContext
+{
+    private static readonly AsyncLocal<IpcContext?> CurrentContext = new();
+
+    /// <summary>The call in progress on the current async flow, or null if there is none.</summary>
+    public static IpcContext? Current => CurrentContext.Value;
+
+    internal IpcContext(IClient? client, CancellationToken cancellationToken)
+    {
+        Client = client;
+        CancellationToken = cancellationToken;
+    }
+
+    /// <summary>The peer of the in-flight call (same handle as <see cref="Message.Client"/>),
+    /// or null when the current endpoint has no reachable peer.</summary>
+    public IClient? Client { get; }
+
+    /// <summary>The cancellation token of the in-flight call.</summary>
+    public CancellationToken CancellationToken { get; }
+
+    /// <summary>Equivalent to <c>Message.Client.GetCallback&lt;TCallback&gt;()</c>.</summary>
+    /// <exception cref="InvalidOperationException"><see cref="Client"/> is null.</exception>
+    public TCallback GetCallback<TCallback>() where TCallback : class
+    => (Client ?? throw new InvalidOperationException(
+            $"{nameof(IpcContext)}.{nameof(Current)} has no peer client; " +
+            $"{nameof(GetCallback)} is only available while honoring a server-side IPC call."))
+        .GetCallback<TCallback>();
+
+    /// <summary>Publishes <paramref name="context"/> as <see cref="Current"/> for the returned
+    /// scope, restoring the previous value on dispose so nested calls compose.</summary>
+    internal static IDisposable Push(IpcContext context)
+    {
+        var previous = CurrentContext.Value;
+        CurrentContext.Value = context;
+        return new Scope(previous);
+    }
+
+    private sealed class Scope : IDisposable
+    {
+        private readonly IpcContext? _previous;
+        private bool _disposed;
+
+        public Scope(IpcContext? previous) => _previous = previous;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            _disposed = true;
+            CurrentContext.Value = _previous;
+        }
+    }
+}

--- a/src/UiPath.CoreIpc/Server/Server.cs
+++ b/src/UiPath.CoreIpc/Server/Server.cs
@@ -167,21 +167,23 @@ internal class Server
             Task<object?> ScheduleMethodCall() => defaultScheduler ? MethodCall() : RunOnScheduler();
             async Task<object?> MethodCall()
             {
-                await (route.BeforeCall?.Invoke(
-                    new CallInfo(newConnection: false, method.MethodInfo, arguments),
-                    cancellationToken) ?? Task.CompletedTask);
-
-                Task invocationTask = null!;
-
-                invocationTask = method.Invoke(service, arguments, cancellationToken);
-                await invocationTask;
-
-                if (!returnTaskType.IsGenericType)
+                // So a POCO contract can reach the peer without a Message parameter.
+                using (IpcContext.Push(new IpcContext(_client, cancellationToken)))
                 {
-                    return null;
-                }
+                    await (route.BeforeCall?.Invoke(
+                        new CallInfo(newConnection: false, method.MethodInfo, arguments),
+                        cancellationToken) ?? Task.CompletedTask);
 
-                return GetTaskResult(returnTaskType, invocationTask);
+                    Task invocationTask = method.Invoke(service, arguments, cancellationToken);
+                    await invocationTask;
+
+                    if (!returnTaskType.IsGenericType)
+                    {
+                        return null;
+                    }
+
+                    return GetTaskResult(returnTaskType, invocationTask);
+                }
             }
 
             Task<object?> RunOnScheduler() => Task.Factory.StartNew(MethodCall, cancellationToken, TaskCreationOptions.DenyChildAttach, scheduler).Unwrap();


### PR DESCRIPTION
**Jira:** [ROBO-5857](https://uipath.atlassian.net/browse/ROBO-5857)

<img width="1789" height="1488" alt="image" src="https://github.com/user-attachments/assets/9d3af527-0127-467e-9bcd-ff981a2922bf" />


## What & why

A strongly-typed contract that wants to **service callbacks** is today forced to reference `UiPath.Ipc`, because reaching the peer requires a `Message` parameter on the contract method. That leaks the transport into the contract-defining assembly and makes bidirectional contracts non-agnostic.

This PR adds an **ambient per-operation context**, `IpcContext`, whose static **`IpcContext.Current`** is non-null exactly while a call is being honored. A contract implementation reaches the peer via `IpcContext.Current.GetCallback<T>()` — **no `Message` parameter** — so the contract-defining assembly can stay free of a `UiPath.Ipc` reference and a bidirectional contract can be written agnostically.

Everything is **additive and non-breaking**: `Message`, `CancellationToken`, and the wire format are unchanged.

## Changes

- **`IpcContext`** (`public sealed class`) with a static `IpcContext? Current` backed by `AsyncLocal`. Exposes `Client`, the call's `CancellationToken`, and `GetCallback<T>()` (the same machinery behind `Message.Client.GetCallback<T>()`).
- Published around the handler invocation in `Server.MethodCall`, so it covers inbound calls **and** callbacks, composes across nested calls (a callback serviced mid-call), and is null outside a call.
- Builds net461 / net6.0 / net6.0-windows.

## Tests

4 xUnit tests driven by a self-contained POCO contract with **no `Message` parameter**: `Current` is null outside a call and after it completes, set while honoring a call, and a `Message`-free contract reaches its callback purely via `IpcContext.Current.GetCallback<T>()`.

## Scope

This PR is **.NET only**. The Python and TypeScript work that previously rode along in this branch has been split out to #148 ([ROBO-5858](https://uipath.atlassian.net/browse/ROBO-5858)) — Python `IpcContext`, plus TypeScript `AbortSignal` acceptance and caller/callee cancellation propagation — so each runtime's concerns can be reviewed on their own. The two PRs are independent and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ROBO-5857]: https://uipath.atlassian.net/browse/ROBO-5857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROBO-5858]: https://uipath.atlassian.net/browse/ROBO-5858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ