### PR TITLE
[ROBO-5816] Upgrade RecyclableMemoryStream to version 3.0.1

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,5 +1,5 @@
 <Project>
     <ItemGroup>
-        <PackageReference Update="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
+        <PackageReference Update="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     </ItemGroup>
 </Project>

--- a/src/UiPath.CoreIpc/Helpers/Helpers.cs
+++ b/src/UiPath.CoreIpc/Helpers/Helpers.cs
@@ -92,7 +92,11 @@ internal static class Helpers
 public static class IOHelpers
 {
     const int MaxBytes = 100 * 1024 * 1024;
-    private static readonly RecyclableMemoryStreamManager Pool = new(MaxBytes, MaxBytes);
+    private static readonly RecyclableMemoryStreamManager Pool = new(options: new()
+    {
+        MaximumLargePoolFreeBytes = MaxBytes,
+        MaximumSmallPoolFreeBytes = MaxBytes
+    });
     internal static MemoryStream GetStream(int size = 0) => Pool.GetStream("IpcMessage", size);
     internal const int HeaderLength = sizeof(int) + 1;
     internal static NamedPipeServerStream NewNamedPipeServerStream(string pipeName, PipeDirection direction, int maxNumberOfServerInstances, PipeTransmissionMode transmissionMode, PipeOptions options, Func<PipeSecurity?> pipeSecurity)


### PR DESCRIPTION
Updated the `Microsoft.IO.RecyclableMemoryStream` package from version 2.2.0 to 3.0.1 in `Directory.Build.targets`.

Refactored `RecyclableMemoryStreamManager` initialization in `Helpers.cs` to use the new `options` object for configuring `MaximumLargePoolFreeBytes` and `MaximumSmallPoolFreeBytes`, aligning with the updated API in the newer library version.