### PR TITLE
Bump UiPath.Ipc version to 2.5.2

### DIFF
--- a/src/UiPath.CoreIpc/UiPath.CoreIpc.csproj
+++ b/src/UiPath.CoreIpc/UiPath.CoreIpc.csproj
@@ -6,7 +6,7 @@
     <GeneratePackageOnBuild Condition="$(Configuration)=='Release'">true</GeneratePackageOnBuild>
     <GeneratePackageOnBuild Condition="$(Configuration)=='Debug'">true</GeneratePackageOnBuild>
     <Authors>UiPath</Authors>
-    <Version>2.5.1</Version>
+    <Version>2.5.2</Version>
     <PackageProjectUrl>https://github.com/UiPath/CoreIpc/</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>json-rpc rpc ipc netcore wcf</PackageTags>


### PR DESCRIPTION
Updated the project version from 2.5.1 to 2.5.2 in the `UiPath.CoreIpc.csproj` file. This minor version increment likely includes bug fixes, small improvements, or other non-breaking changes.