### PR TITLE
ci: publish uipath-ipc to public PyPI via GitHub Actions (ADO-triggered, OIDC)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,163 @@
+name: Publish uipath-ipc to PyPI
+
+# Publishes uipath-ipc to public PyPI via Trusted Publishing (OIDC) — no tokens.
+# ADO stays primary; on a green publish it POSTs a repository_dispatch (publish-pypi)
+# with the released commit SHA, and this builds & publishes that commit. Only master
+# publishes (dispatch runs the default-branch file; the build refuses non-master
+# commits) and there is no workflow_dispatch, so it can't fire by accident. Prereqs:
+# a PyPI Trusted Publisher (UiPath/coreipc, workflow cd.yml, env pypi) + protected `pypi` env.
+
+on:
+  repository_dispatch:
+    types: [publish-pypi]
+
+permissions:
+  contents: read
+
+# Never let two publish runs race for the same package.
+concurrency:
+  group: publish-pypi-uipath-ipc
+  cancel-in-progress: false
+
+env:
+  PACKAGE_DIR: src/Clients/python/uipath-ipc
+  CSPROJ: src/UiPath.CoreIpc/UiPath.CoreIpc.csproj
+
+jobs:
+  build:
+    name: Build wheel + sdist
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      # Untrusted input (client_payload.sha) is read via env, never inlined into
+      # a run: script, and validated as a 40-char hex commit — script-injection
+      # hardening + rejects tags/branch-names (we require an exact commit).
+      - name: Resolve & validate commit SHA
+        id: ref
+        env:
+          DISPATCH_SHA: ${{ github.event.client_payload.sha }}
+        run: |
+          set -euo pipefail
+          REF="$DISPATCH_SHA"
+          if [ -z "$REF" ]; then echo "::error::No client_payload.sha provided."; exit 1; fi
+          if ! printf '%s' "$REF" | grep -Eq '^[0-9a-fA-F]{40}$'; then
+            echo "::error::client_payload.sha '$REF' is not a 40-char commit hash — refusing."; exit 1
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout exact commit (full history)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.ref.outputs.ref }}
+          fetch-depth: 0        # full graph — needed to prove the commit is on master
+
+      # Enforce "only master publishes" at the source level: refuse any commit
+      # that is not merged into master. Combined with repository_dispatch always
+      # running the default-branch copy of this file, unmerged/branch code can
+      # never reach public PyPI.
+      - name: Refuse commits that are not on master
+        env:
+          SHA: ${{ steps.ref.outputs.ref }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin master
+          if ! git merge-base --is-ancestor "$SHA" FETCH_HEAD; then
+            echo "::error::Commit $SHA is not an ancestor of origin/master — only master-merged code may be published to PyPI."
+            exit 1
+          fi
+          echo "$SHA is on master — OK"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # Version comes from the SAME commit we build (single source of truth) and
+      # is validated as a clean PEP 440 RELEASE version. A CI/dev build (local
+      # +segment) or a non-PEP-440 string (e.g. .NET-style '2.5.2-rc1') is
+      # REJECTED rather than silently mangled into the wrong release.
+      - name: Resolve & validate version (PEP 440, no local segment)
+        id: resolve
+        run: |
+          set -euo pipefail
+          python -m pip install --quiet --upgrade packaging
+          python - "$CSPROJ" <<'PY'
+          import os, sys, xml.etree.ElementTree as ET
+          from packaging.version import Version, InvalidVersion
+
+          root = ET.parse(sys.argv[1]).getroot()
+          vals = [e.text.strip() for e in root.iter()
+                  if e.tag.split('}')[-1] == 'Version' and (e.text or '').strip()]
+          if not vals:
+              sys.exit(f"::error::No <Version> found in {sys.argv[1]}")
+          raw = vals[0]
+
+          if "+" in raw:
+              sys.exit(f"::error::Version '{raw}' has a PEP 440 local segment (+...); "
+                       "that is a CI/dev build, not a release — refusing to publish.")
+          try:
+              v = Version(raw)          # rejects .NET-style '2.5.2-rc1'
+          except InvalidVersion:
+              sys.exit(f"::error::Version '{raw}' is not a valid PEP 440 release version. "
+                       "Set a clean version (e.g. 2.5.2 or 2.5.2rc1) before publishing.")
+          if v.local:
+              sys.exit(f"::error::Version '{raw}' has a local segment — refusing.")
+          with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+              fh.write(f"version={raw}\n")
+          print(f"Publishing version: {raw}")
+          PY
+
+      - name: Stamp version into pyproject.toml
+        # Reuse the repo's own stamper (single source of truth). With a clean
+        # dash-free version its to_pep440() is the identity.
+        run: |
+          set -euo pipefail
+          python src/CI/stamp-python-version.py \
+            "${{ steps.resolve.outputs.version }}" \
+            "$PACKAGE_DIR/pyproject.toml"
+
+      - name: Build wheel + sdist
+        working-directory: ${{ env.PACKAGE_DIR }}
+        run: |
+          set -euo pipefail
+          python -m pip install --quiet --upgrade build
+          python -m build
+
+      - name: Verify distributions are PyPI-legal
+        working-directory: ${{ env.PACKAGE_DIR }}
+        run: |
+          set -euo pipefail
+          python -m pip install --quiet --upgrade twine
+          python -m twine check dist/*
+          if ls dist/ | grep -q '+'; then
+            echo "::error::A local version segment (+) leaked into a dist filename — refusing to publish."
+            exit 1
+          fi
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists-uipath-ipc
+          path: ${{ env.PACKAGE_DIR }}/dist/
+
+  publish:
+    name: Publish to PyPI (Trusted Publishing)
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi          # MANDATORY protection (required reviewers + default-branch only)
+    permissions:
+      contents: read
+      id-token: write          # OIDC Trusted Publishing — no long-lived token
+    steps:
+      - name: Retrieve distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists-uipath-ipc
+          path: dist/
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+          skip-existing: true

--- a/src/CI/azp-publish.yaml
+++ b/src/CI/azp-publish.yaml
@@ -155,3 +155,81 @@ stages:
                 parameters:
                   reuseArtifactsFromBuildId: ${{ parameters.buildId }}
                   sourcePipelineId: $(resources.pipeline.ci.pipelineID)
+
+# Whisper to GitHub to publish the same release to public PyPI. dependsOn every
+# emitted publish stage with condition: succeeded(), so it fires only if all of them
+# succeeded — no PyPI publish on any ADO failure. It resolves the published buildId's
+# exact commit (ADO REST) and gates upstream — only a genuine NEW MASTER release
+# whispers (branch builds and already-published versions are skipped), so the GitHub
+# Action is never triggered just to refuse. Needs var group `github-dispatch`.
+- ${{ if and(not(in(parameters.buildId, '', '0')), eq(parameters.publishPyPI, true)) }}:
+  - stage: Notify_GitHub
+    displayName: '📣 Notify GitHub → PyPI (master, new version only)'
+    dependsOn:
+      - ${{ if eq(parameters.publishNuGet, true) }}:
+        - Publish_NuGet
+      - ${{ if eq(parameters.publishNpm, true) }}:
+        - Publish_NPM
+      - Publish_PyPI
+    condition: succeeded()
+    variables:
+      - group: github-dispatch          # supplies secret GITHUB_DISPATCH_TOKEN
+    jobs:
+    - job: dispatch
+      displayName: 'repository_dispatch → UiPath/coreipc'
+      pool:
+        vmImage: 'ubuntu-latest'
+      steps:
+        - checkout: none
+        - script: |
+            set -euo pipefail
+            # 1. Resolve the published build's branch + commit (ADO REST).
+            build=$(curl -sSf -H "Authorization: Bearer $SYSTEM_ACCESSTOKEN" \
+              "${SYSTEM_COLLECTIONURI}${SYSTEM_TEAMPROJECT}/_apis/build/builds/${BUILD_ID}?api-version=7.1")
+            SHA=$(printf '%s' "$build" | jq -r '.sourceVersion')
+            BRANCH=$(printf '%s' "$build" | jq -r '.sourceBranch')
+            echo "buildId ${BUILD_ID}: branch=${BRANCH} commit=${SHA}"
+
+            # 2. GATE — public PyPI gets MASTER releases only. For anything else,
+            #    skip the whisper entirely so the GitHub Action is never triggered
+            #    just to refuse (saves a wasted runner).
+            if [ "$BRANCH" != "refs/heads/master" ]; then
+              echo "Not a master build (${BRANCH}) — skipping public PyPI dispatch."
+              exit 0
+            fi
+            if ! printf '%s' "$SHA" | grep -Eq '^[0-9a-fA-F]{40}$'; then
+              echo "##vso[task.logissue type=error]No valid commit SHA for buildId ${BUILD_ID} (got '${SHA}')."
+              exit 1
+            fi
+
+            # 3. GATE — skip if this version is already on PyPI, so we never fire a
+            #    no-op run. Version = <Version> from the csproj AT that commit
+            #    (public repo → unauthenticated raw read).
+            VERSION=$(curl -sSf -H "Accept: application/vnd.github.raw" \
+              "https://api.github.com/repos/UiPath/coreipc/contents/src/UiPath.CoreIpc/UiPath.CoreIpc.csproj?ref=${SHA}" \
+              | grep -oPm1 '(?<=<Version>)[^<]+' | tr -d '[:space:]')
+            if [ -z "$VERSION" ]; then
+              echo "##vso[task.logissue type=error]Could not read <Version> from csproj at ${SHA}."
+              exit 1
+            fi
+            code=$(curl -sS -o /dev/null -w '%{http_code}' "https://pypi.org/pypi/uipath-ipc/${VERSION}/json")
+            if [ "$code" = "200" ]; then
+              echo "uipath-ipc ${VERSION} already on PyPI — nothing to publish, skipping dispatch."
+              exit 0
+            fi
+
+            # 4. New master release → whisper to GitHub to publish it.
+            echo "Dispatching publish-pypi for uipath-ipc ${VERSION} (${SHA})"
+            curl -sSf -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GITHUB_DISPATCH_TOKEN" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/UiPath/coreipc/dispatches \
+              -d "{\"event_type\":\"publish-pypi\",\"client_payload\":{\"sha\":\"${SHA}\"}}"
+          displayName: 'Gate on master + unpublished version, then dispatch'
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+            SYSTEM_COLLECTIONURI: $(System.CollectionUri)
+            SYSTEM_TEAMPROJECT: $(System.TeamProject)
+            BUILD_ID: ${{ parameters.buildId }}
+            GITHUB_DISPATCH_TOKEN: $(GITHUB_DISPATCH_TOKEN)


### PR DESCRIPTION
## Background — how we ended up here
- **`uipath-ipc` has to be on public PyPI.** `uipath-python` depends on it, so for a plain `pip install uipath` to resolve, `uipath-ipc` can't live only on the internal Azure feed — it must be published to PyPI.
- **PyPI publishing has to come from GitHub Actions.** PyPI's sanctioned auth is Trusted Publishing (OIDC), which PyPI supports from GitHub Actions — not from Azure DevOps. So the PyPI upload has to originate in a GitHub Action.
- **But coreipc releases on ADO, and we're keeping it there.** So ADO stays primary and simply hands the PyPI step off to GitHub.

## How it works
ADO stays the primary build/test/internal-feed pipeline, unchanged. On a green `azp-publish` run **for a new master release**, it POSTs a `repository_dispatch` to GitHub carrying the released commit SHA; `cd.yml` then builds that commit and publishes to PyPI via **Trusted Publishing (OIDC)** — no tokens on the publish side.

## Properties
- **Master only** — the dispatch always runs the default-branch workflow, and the build refuses any commit not merged to master.
- **No accidental runs** — dispatch-only (no UI trigger); ADO only whispers for a genuine new release, so the Action is never fired just to refuse.
- **Internal feed untouched** — the UiPath-Internal publish is unchanged and independent; the PyPI whisper is downstream of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)