### PR TITLE
bump Ipc from 2.5.2 to 2.5.3

### DIFF
--- a/src/UiPath.CoreIpc/UiPath.CoreIpc.csproj
+++ b/src/UiPath.CoreIpc/UiPath.CoreIpc.csproj
@@ -6,7 +6,7 @@
     <GeneratePackageOnBuild Condition="$(Configuration)=='Release'">true</GeneratePackageOnBuild>
     <GeneratePackageOnBuild Condition="$(Configuration)=='Debug'">true</GeneratePackageOnBuild>
     <Authors>UiPath</Authors>
-    <Version>2.5.2</Version>
+    <Version>2.5.3</Version>
     <PackageProjectUrl>https://github.com/UiPath/CoreIpc/</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>json-rpc rpc ipc netcore wcf</PackageTags>


### PR DESCRIPTION
**Why:**
2.5.2 already landed on [PyPi](https://pypi.org/project/uipath-ipc/)
