### PR TITLE
chore: change to centralized managed GitHub pool

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   build:
     name: Build wheel + sdist
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     outputs:
       version: ${{ steps.resolve.outputs.version }}
     steps:
@@ -47,7 +47,7 @@ jobs:
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
 
       - name: Checkout exact commit (full history)
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           ref: ${{ steps.ref.outputs.ref }}
           fetch-depth: 0        # full graph — needed to prove the commit is on master
@@ -69,7 +69,7 @@ jobs:
           echo "$SHA is on master — OK"
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.12'
 
@@ -136,7 +136,7 @@ jobs:
           fi
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: release-dists-uipath-ipc
           path: ${{ env.PACKAGE_DIR }}/dist/
@@ -144,20 +144,20 @@ jobs:
   publish:
     name: Publish to PyPI (Trusted Publishing)
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     environment: pypi          # MANDATORY protection (required reviewers + default-branch only)
     permissions:
       contents: read
       id-token: write          # OIDC Trusted Publishing — no long-lived token
     steps:
       - name: Retrieve distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: release-dists-uipath-ipc
           path: dist/
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1
         with:
           verbose: true
           skip-existing: true


### PR DESCRIPTION
## Summary

Moves this repository's workflows to the centralized managed GitHub pool.

- Runner images are prefixed with `uipath-` in all workflow files
- e.g. `ubuntu-latest` → `uipath-ubuntu-latest`

## Changes

All workflow `.yml` files (including non-standard locations like `workflows-src/`) with static `runs-on` values are updated.
Dynamic expressions (`${{ ... }}`) and already-prefixed images are skipped.

## Action Version Pinning

All `uses:` references are pinned to the SHA of the latest release published ≥ **48h** ago.
This prevents supply-chain attacks via recently-published compromised versions.